### PR TITLE
Implement parsing ArrayType and SetType

### DIFF
--- a/ast/const.go
+++ b/ast/const.go
@@ -62,3 +62,5 @@ type ConstExpr = Expression
 func NewConstExpr(arg interface{}) *ConstExpr {
 	return NewExpression(arg)
 }
+
+type ConstExprs = ExprList

--- a/ast/type.go
+++ b/ast/type.go
@@ -112,8 +112,6 @@ func NewTypeId(unitIdOrIdent interface{}, args ...interface{}) *TypeId {
 	}
 }
 
-func (*TypeId) isType()       {}
-func (*TypeId) isSimpleType() {}
 func (m *TypeId) Children() Nodes {
 	r := Nodes{}
 	if m.UnitId != nil {
@@ -121,6 +119,25 @@ func (m *TypeId) Children() Nodes {
 	}
 	r = append(r, m.Ident)
 	return r
+}
+
+func (*TypeId) isType() {}
+func (m *TypeId) IsSimpleType() bool {
+	if m.Ref == nil {
+		return false
+	}
+	if m.Ref.Node == nil {
+		return false
+	}
+	decl, ok := m.Ref.Node.(*TypeDecl)
+	if !ok {
+		return false
+	}
+	simpleType, ok := decl.Type.(SimpleType)
+	if !ok {
+		return false
+	}
+	return simpleType.IsSimpleType()
 }
 
 func (m *TypeId) IsOrdinalType() bool {

--- a/ast/type.go
+++ b/ast/type.go
@@ -112,7 +112,8 @@ func NewTypeId(unitIdOrIdent interface{}, args ...interface{}) *TypeId {
 	}
 }
 
-func (*TypeId) isType() {}
+func (*TypeId) isType()       {}
+func (*TypeId) isSimpleType() {}
 func (m *TypeId) Children() Nodes {
 	r := Nodes{}
 	if m.UnitId != nil {
@@ -120,4 +121,22 @@ func (m *TypeId) Children() Nodes {
 	}
 	r = append(r, m.Ident)
 	return r
+}
+
+func (m *TypeId) IsOrdinalType() bool {
+	if m.Ref == nil {
+		return false
+	}
+	if m.Ref.Node == nil {
+		return false
+	}
+	decl, ok := m.Ref.Node.(*TypeDecl)
+	if !ok {
+		return false
+	}
+	ordinalType, ok := decl.Type.(OrdinalType)
+	if !ok {
+		return false
+	}
+	return ordinalType.IsOrdinalType()
 }

--- a/ast/type_simple.go
+++ b/ast/type_simple.go
@@ -81,8 +81,9 @@ func (m *RealType) Children() Nodes { return Nodes{m.Ident} }
 //   ```
 
 type OrdinalType interface {
+	IsOrdinalType() bool
+	// implements
 	SimpleType
-	isOrdinalType()
 }
 
 // - OrdIdent
@@ -170,10 +171,10 @@ func NewOrdIdent(name interface{}) *OrdIdent {
 	}
 }
 
-func (*OrdIdent) isType()           {}
-func (*OrdIdent) isSimpleType()     {}
-func (*OrdIdent) isOrdinalType()    {}
-func (m *OrdIdent) Children() Nodes { return Nodes{m.Ident} }
+func (*OrdIdent) isType()             {}
+func (*OrdIdent) isSimpleType()       {}
+func (*OrdIdent) IsOrdinalType() bool { return true }
+func (m *OrdIdent) Children() Nodes   { return Nodes{m.Ident} }
 
 // - EnumeratedType
 //   ```
@@ -185,9 +186,9 @@ func (m *OrdIdent) Children() Nodes { return Nodes{m.Ident} }
 //   ```
 type EnumeratedType []*EnumeratedTypeElement // must implement OrdinalType
 
-func (EnumeratedType) isType()        {}
-func (EnumeratedType) isSimpleType()  {}
-func (EnumeratedType) isOrdinalType() {}
+func (EnumeratedType) isType()             {}
+func (EnumeratedType) isSimpleType()       {}
+func (EnumeratedType) IsOrdinalType() bool { return true }
 func (m EnumeratedType) Children() Nodes {
 	r := make(Nodes, len(m))
 	for i, e := range m {
@@ -223,7 +224,7 @@ type SubrangeType struct {
 	High *ConstExpr
 }
 
-func (*SubrangeType) isType()           {}
-func (*SubrangeType) isSimpleType()     {}
-func (*SubrangeType) isOrdinalType()    {}
-func (m *SubrangeType) Children() Nodes { return Nodes{m.Low, m.High} }
+func (*SubrangeType) isType()             {}
+func (*SubrangeType) isSimpleType()       {}
+func (*SubrangeType) IsOrdinalType() bool { return true }
+func (m *SubrangeType) Children() Nodes   { return Nodes{m.Low, m.High} }

--- a/ast/type_simple.go
+++ b/ast/type_simple.go
@@ -14,7 +14,7 @@ import (
 //   ```
 type SimpleType interface {
 	Type
-	isSimpleType()
+	IsSimpleType() bool
 }
 
 // - RealType
@@ -71,9 +71,9 @@ func NewRealType(name interface{}) *RealType {
 	}
 }
 
-func (*RealType) isType()           {}
-func (*RealType) isSimpleType()     {}
-func (m *RealType) Children() Nodes { return Nodes{m.Ident} }
+func (*RealType) isType()            {}
+func (*RealType) IsSimpleType() bool { return true }
+func (m *RealType) Children() Nodes  { return Nodes{m.Ident} }
 
 // - OrdinalType
 //   ```
@@ -172,7 +172,7 @@ func NewOrdIdent(name interface{}) *OrdIdent {
 }
 
 func (*OrdIdent) isType()             {}
-func (*OrdIdent) isSimpleType()       {}
+func (*OrdIdent) IsSimpleType() bool  { return true }
 func (*OrdIdent) IsOrdinalType() bool { return true }
 func (m *OrdIdent) Children() Nodes   { return Nodes{m.Ident} }
 
@@ -187,7 +187,7 @@ func (m *OrdIdent) Children() Nodes   { return Nodes{m.Ident} }
 type EnumeratedType []*EnumeratedTypeElement // must implement OrdinalType
 
 func (EnumeratedType) isType()             {}
-func (EnumeratedType) isSimpleType()       {}
+func (EnumeratedType) IsSimpleType() bool  { return true }
 func (EnumeratedType) IsOrdinalType() bool { return true }
 func (m EnumeratedType) Children() Nodes {
 	r := make(Nodes, len(m))
@@ -225,6 +225,6 @@ type SubrangeType struct {
 }
 
 func (*SubrangeType) isType()             {}
-func (*SubrangeType) isSimpleType()       {}
+func (*SubrangeType) IsSimpleType() bool  { return true }
 func (*SubrangeType) IsOrdinalType() bool { return true }
 func (m *SubrangeType) Children() Nodes   { return Nodes{m.Low, m.High} }

--- a/ast/type_struc.go
+++ b/ast/type_struc.go
@@ -19,7 +19,8 @@ type StrucType interface {
 //   ARRAY ['[' OrdinalType ','... ']'] OF Type [PortabilityDirective]
 //   ```
 type ArrayType struct {
-	IndexTypes []OrdinalType
+	// IndexTypes []OrdinalType
+	IndexTypes []Type // OrdinalType or TypeId to OrdinalType
 	BaseType   Type
 	Packed     bool
 	// implements

--- a/ast/type_struc.go
+++ b/ast/type_struc.go
@@ -1,0 +1,170 @@
+package ast
+
+import "github.com/akm/tparser/ast/astcore"
+
+// - StrucType
+//   ```
+//   [PACKED] (ArrayType [PACKED]| SetType | FileType | RecType [PACKED])
+//   ```
+// NOTICE this is NOT "StructType" but "StrucType"
+type StrucType interface {
+	isStrucType()
+	IsPacked() bool
+	// inherits
+	Type
+}
+
+// - ArrayType
+//   ```
+//   ARRAY ['[' OrdinalType ','... ']'] OF Type [PortabilityDirective]
+//   ```
+type ArrayType struct {
+	IndexTypes []OrdinalType
+	BaseType   Type
+	Packed     bool
+	// implements
+	StrucType
+}
+
+func (*ArrayType) isType()          {}
+func (*ArrayType) isStrucType()     {}
+func (m *ArrayType) IsPacked() bool { return m.Packed }
+func (m *ArrayType) Children() Nodes {
+	r := make(Nodes, len(m.IndexTypes)+1)
+	for i, m := range m.IndexTypes {
+		r[i] = m
+	}
+	r[len(m.IndexTypes)] = m.BaseType
+	return r
+}
+
+// - SetType
+//   ```
+//   SET OF OrdinalType [PortabilityDirective]
+//   ```
+type SetType struct {
+	OrdinalType
+	Packed bool
+	// implements
+	StrucType
+}
+
+func (*SetType) isType()          {}
+func (*SetType) isStrucType()     {}
+func (m *SetType) IsPacked() bool { return m.Packed }
+func (m *SetType) Children() Nodes {
+	return Nodes{m.OrdinalType}
+}
+
+// - FileType
+//   ```
+//   FILE OF TypeId [PortabilityDirective]
+//   ```
+type FileType struct {
+	*TypeId
+	Packed bool
+	// implements
+	StrucType
+}
+
+func (*FileType) isType()          {}
+func (*FileType) isStrucType()     {}
+func (m *FileType) IsPacked() bool { return m.Packed }
+func (m *FileType) Children() Nodes {
+	return Nodes{m.TypeId}
+}
+
+// - RecType
+//   ```
+//   RECORD [FieldList] END [PortabilityDirective]
+//   ```
+type RecType struct {
+	FieldList *FieldList
+	Packed    bool
+	// implements
+	StrucType
+}
+
+func (*RecType) isType()          {}
+func (*RecType) isStrucType()     {}
+func (m *RecType) IsPacked() bool { return m.Packed }
+func (m *RecType) Children() Nodes {
+	return Nodes{m.FieldList}
+}
+
+// - FieldList
+//   ```
+//   FieldDecl ';'... [VariantSection] [';']
+//   ```
+type FieldList struct {
+	FieldDecl      *FieldDecl
+	VariantSection *VariantSection
+	// implements
+	Node
+}
+
+func (m *FieldList) Children() Nodes {
+	return Nodes{m.FieldDecl, m.VariantSection}
+}
+
+// - FieldDecl
+//   ```
+//   IdentList ':' Type [PortabilityDirective]
+//   ```
+type FieldDecl struct {
+	IdentList IdentList
+	Type      Type
+	//PortabilityDirective
+	// implements
+	astcore.DeclNode
+}
+
+func (m *FieldDecl) Children() Nodes {
+	return Nodes{m.Type}
+}
+
+func (m *FieldDecl) ToDeclarations() astcore.Decls {
+	return astcore.NewDeclarations(m.IdentList, m)
+}
+
+// - VariantSection
+//   ```
+//   CASE [Ident ':'] TypeId OF RecVariant ';'...
+//   ```
+type VariantSection struct {
+	Ident       *Ident
+	TypeId      *TypeId
+	RecVariants RecVariants
+	// implements
+	Node
+}
+
+func (m *VariantSection) Children() Nodes {
+	return Nodes{m.TypeId, m.RecVariants}
+}
+
+// implements Node
+type RecVariants []*RecVariant
+
+func (s RecVariants) Children() Nodes {
+	r := make(Nodes, len(s))
+	for i, m := range s {
+		r[i] = m
+	}
+	return r
+}
+
+// - RecVariant
+//   ```
+//   ConstExpr ','... ':' '(' [FieldList] ')'
+//   ```
+type RecVariant struct {
+	ConstExprs ConstExprs
+	FieldList  *FieldList
+	// implements
+	Node
+}
+
+func (m *RecVariant) Children() Nodes {
+	return Nodes{m.ConstExprs, m.FieldList}
+}

--- a/ast/type_struc.go
+++ b/ast/type_struc.go
@@ -19,8 +19,7 @@ type StrucType interface {
 //   ARRAY ['[' OrdinalType ','... ']'] OF Type [PortabilityDirective]
 //   ```
 type ArrayType struct {
-	// IndexTypes []OrdinalType
-	IndexTypes []Type // OrdinalType or TypeId to OrdinalType
+	IndexTypes []OrdinalType
 	BaseType   Type
 	Packed     bool
 	// implements

--- a/parser/parsertest/run.go
+++ b/parser/parsertest/run.go
@@ -1,0 +1,25 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/akm/tparser/ast"
+	"github.com/akm/tparser/ast/asttest"
+	"github.com/stretchr/testify/assert"
+)
+
+func runType(t *testing.T, name string, text []rune, expected ast.Type, funcs ...func() interface{}) {
+	t.Run(name, func(t *testing.T) {
+		args := make([]interface{}, len(funcs))
+		for i, f := range funcs {
+			args[i] = f()
+		}
+		parser := NewTestParser(&text, args...)
+		parser.NextToken()
+		res, err := parser.ParseType()
+		if assert.NoError(t, err) {
+			asttest.ClearLocations(t, res)
+			assert.Equal(t, expected, res)
+		}
+	})
+}

--- a/parser/parsertest/run.go
+++ b/parser/parsertest/run.go
@@ -23,3 +23,21 @@ func runType(t *testing.T, name string, text []rune, expected ast.Type, funcs ..
 		}
 	})
 }
+
+func runTypeDecl(t *testing.T, name string, text []rune, expected *ast.TypeDecl, funcs ...func() interface{}) {
+	t.Run(name, func(t *testing.T) {
+		args := make([]interface{}, len(funcs))
+		for i, f := range funcs {
+			args[i] = f()
+		}
+		parser := NewTestParser(&text, args...)
+		parser.NextToken()
+		res, err := parser.ParseTypeDecl()
+		if assert.NoError(t, err) {
+			asttest.ClearLocations(t, res)
+			if !assert.Equal(t, expected, res) {
+				asttest.AssertTypeDecl(t, expected, res)
+			}
+		}
+	})
+}

--- a/parser/parsertest/type_struc_array_test.go
+++ b/parser/parsertest/type_struc_array_test.go
@@ -31,7 +31,7 @@ func TestStrucArray(t *testing.T) {
 		"Char array",
 		[]rune(`array[1..100] of Char`),
 		&ast.ArrayType{
-			IndexTypes: []ast.Type{
+			IndexTypes: []ast.OrdinalType{
 				&ast.SubrangeType{
 					Low:  asttest.NewConstExpr(asttest.NewNumber("1")),
 					High: asttest.NewConstExpr(asttest.NewNumber("100")),
@@ -45,14 +45,14 @@ func TestStrucArray(t *testing.T) {
 		"Matrix by array of array",
 		[]rune(`array[1..10] of array[1..50] of Real`),
 		&ast.ArrayType{
-			IndexTypes: []ast.Type{
+			IndexTypes: []ast.OrdinalType{
 				&ast.SubrangeType{
 					Low:  asttest.NewConstExpr(asttest.NewNumber("1")),
 					High: asttest.NewConstExpr(asttest.NewNumber("10")),
 				},
 			},
 			BaseType: &ast.ArrayType{
-				IndexTypes: []ast.Type{
+				IndexTypes: []ast.OrdinalType{
 					&ast.SubrangeType{
 						Low:  asttest.NewConstExpr(asttest.NewNumber("1")),
 						High: asttest.NewConstExpr(asttest.NewNumber("50")),
@@ -67,7 +67,7 @@ func TestStrucArray(t *testing.T) {
 		"Matrix by array with 2 indexes",
 		[]rune(`array[1..10, 1..50] of Real`),
 		&ast.ArrayType{
-			IndexTypes: []ast.Type{
+			IndexTypes: []ast.OrdinalType{
 				&ast.SubrangeType{
 					Low:  asttest.NewConstExpr(asttest.NewNumber("1")),
 					High: asttest.NewConstExpr(asttest.NewNumber("10")),
@@ -100,7 +100,7 @@ func TestStrucArray(t *testing.T) {
 		[]rune(`packed array[Boolean,1..10,TShoeSize] of Integer`),
 		&ast.ArrayType{
 			Packed: true,
-			IndexTypes: []ast.Type{
+			IndexTypes: []ast.OrdinalType{
 				&ast.OrdIdent{Ident: asttest.NewIdent("Boolean")},
 				&ast.SubrangeType{
 					Low:  asttest.NewConstExpr(asttest.NewNumber("1")),
@@ -121,12 +121,12 @@ func TestStrucArray(t *testing.T) {
 		[]rune(`packed array[Boolean] of packed array[1..10] of packed array[TShoeSize] of Integer`),
 		&ast.ArrayType{
 			Packed: true,
-			IndexTypes: []ast.Type{
+			IndexTypes: []ast.OrdinalType{
 				&ast.OrdIdent{Ident: asttest.NewIdent("Boolean")},
 			},
 			BaseType: &ast.ArrayType{
 				Packed: true,
-				IndexTypes: []ast.Type{
+				IndexTypes: []ast.OrdinalType{
 					&ast.SubrangeType{
 						Low:  asttest.NewConstExpr(asttest.NewNumber("1")),
 						High: asttest.NewConstExpr(asttest.NewNumber("10")),
@@ -134,7 +134,7 @@ func TestStrucArray(t *testing.T) {
 				},
 				BaseType: &ast.ArrayType{
 					Packed: true,
-					IndexTypes: []ast.Type{
+					IndexTypes: []ast.OrdinalType{
 						&ast.TypeId{
 							Ident: asttest.NewIdent("TShoeSize"),
 							Ref:   tshoeSizeDecl.ToDeclarations()[0],

--- a/parser/parsertest/type_struc_array_test.go
+++ b/parser/parsertest/type_struc_array_test.go
@@ -12,19 +12,7 @@ import (
 
 func TestStrucArray(t *testing.T) {
 	run := func(name string, text []rune, expected ast.Type, funcs ...func() interface{}) {
-		t.Run(name, func(t *testing.T) {
-			args := make([]interface{}, len(funcs))
-			for i, f := range funcs {
-				args[i] = f()
-			}
-			parser := NewTestParser(&text, args...)
-			parser.NextToken()
-			res, err := parser.ParseType()
-			if assert.NoError(t, err) {
-				asttest.ClearLocations(t, res)
-				assert.Equal(t, expected, res)
-			}
-		})
+		runType(t, name, text, expected, funcs...)
 	}
 
 	run(

--- a/parser/parsertest/type_struc_array_test.go
+++ b/parser/parsertest/type_struc_array_test.go
@@ -11,11 +11,7 @@ import (
 )
 
 func TestStrucArray(t *testing.T) {
-	run := func(name string, text []rune, expected ast.Type, funcs ...func() interface{}) {
-		runType(t, name, text, expected, funcs...)
-	}
-
-	run(
+	NewTypeTest(t,
 		"Char array",
 		[]rune(`array[1..100] of Char`),
 		&ast.ArrayType{
@@ -27,9 +23,9 @@ func TestStrucArray(t *testing.T) {
 			},
 			BaseType: &ast.OrdIdent{Ident: asttest.NewIdent("Char")},
 		},
-	)
+	).Run().RunVarSection("MyArray")
 
-	run(
+	NewTypeTest(t,
 		"Matrix by array of array",
 		[]rune(`array[1..10] of array[1..50] of Real`),
 		&ast.ArrayType{
@@ -49,9 +45,9 @@ func TestStrucArray(t *testing.T) {
 				BaseType: &ast.RealType{Ident: asttest.NewIdent("Real")},
 			},
 		},
-	)
+	).Run().RunTypeSection("TMatrix")
 
-	run(
+	NewTypeTest(t,
 		"Matrix by array with 2 indexes",
 		[]rune(`array[1..10, 1..50] of Real`),
 		&ast.ArrayType{
@@ -67,7 +63,7 @@ func TestStrucArray(t *testing.T) {
 			},
 			BaseType: &ast.RealType{Ident: asttest.NewIdent("Real")},
 		},
-	)
+	).Run().RunTypeSection("TMatrix")
 
 	tshoeSizeDecl := &ast.TypeDecl{
 		Ident: asttest.NewIdent("TShoeSize"),
@@ -83,7 +79,7 @@ func TestStrucArray(t *testing.T) {
 		return r
 	}
 
-	run(
+	NewTypeTest(t,
 		"array with 3 complicated indexes",
 		[]rune(`packed array[Boolean,1..10,TShoeSize] of Integer`),
 		&ast.ArrayType{
@@ -102,9 +98,9 @@ func TestStrucArray(t *testing.T) {
 			BaseType: &ast.OrdIdent{Ident: asttest.NewIdent("Integer")},
 		},
 		tshoeSizeContext,
-	)
+	).Run()
 
-	run(
+	NewTypeTest(t,
 		"nested arrays",
 		[]rune(`packed array[Boolean] of packed array[1..10] of packed array[TShoeSize] of Integer`),
 		&ast.ArrayType{
@@ -133,18 +129,18 @@ func TestStrucArray(t *testing.T) {
 			},
 		},
 		tshoeSizeContext,
-	)
+	).Run()
 
-	run(
+	NewTypeTest(t,
 		"dynamic arrays",
 		[]rune(`array of Real`),
 		&ast.ArrayType{
 			IndexTypes: nil,
 			BaseType:   &ast.RealType{Ident: asttest.NewIdent("Real")},
 		},
-	)
+	).Run().RunVarSection("MyFlexibleArray")
 
-	run(
+	NewTypeTest(t,
 		"multidementional dynamic arrays",
 		[]rune(`array of array of string`),
 		&ast.ArrayType{
@@ -154,5 +150,5 @@ func TestStrucArray(t *testing.T) {
 				BaseType:   &ast.StringType{Name: "STRING"},
 			},
 		},
-	)
+	).Run().RunTypeSection("TMessageGrid")
 }

--- a/parser/parsertest/type_struc_array_test.go
+++ b/parser/parsertest/type_struc_array_test.go
@@ -143,4 +143,16 @@ func TestStrucArray(t *testing.T) {
 			BaseType:   &ast.RealType{Ident: asttest.NewIdent("Real")},
 		},
 	)
+
+	run(
+		"multidementional dynamic arrays",
+		[]rune(`array of array of string`),
+		&ast.ArrayType{
+			IndexTypes: nil,
+			BaseType: &ast.ArrayType{
+				IndexTypes: nil,
+				BaseType:   &ast.StringType{Name: "STRING"},
+			},
+		},
+	)
 }

--- a/parser/parsertest/type_struc_set_test.go
+++ b/parser/parsertest/type_struc_set_test.go
@@ -1,0 +1,90 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/akm/tparser/ast"
+	"github.com/akm/tparser/ast/astcore"
+	"github.com/akm/tparser/ast/asttest"
+	"github.com/akm/tparser/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStrucSet(t *testing.T) {
+	tsomeInts := &ast.TypeDecl{
+		Ident: asttest.NewIdent("TSomeInts"),
+		Type: &ast.SubrangeType{
+			Low:  asttest.NewConstExpr(asttest.NewNumber("1")),
+			High: asttest.NewConstExpr(asttest.NewNumber("250")),
+		},
+	}
+	tsomeIntsContext := func() interface{} {
+		declMap := astcore.NewDeclMap()
+		assert.NoError(t, declMap.Set(tsomeInts))
+		r := parser.NewContext(declMap)
+		return r
+	}
+
+	runType(t,
+		"Set with TypeId",
+		[]rune(`set of TSomeInts`),
+		&ast.SetType{
+			OrdinalType: &ast.TypeId{
+				Ident: asttest.NewIdent("TSomeInts"),
+				Ref:   tsomeInts.ToDeclarations()[0],
+			},
+		},
+		tsomeIntsContext,
+	)
+
+	runType(t,
+		"Set with subrange type",
+		[]rune(`set of 1..250`),
+		&ast.SetType{
+			OrdinalType: &ast.SubrangeType{
+				Low:  asttest.NewConstExpr(asttest.NewNumber("1")),
+				High: asttest.NewConstExpr(asttest.NewNumber("250")),
+			},
+		},
+	)
+
+	runType(t,
+		"Set with a to z",
+		[]rune(`set of 'a'..'z'`),
+		&ast.SetType{
+			OrdinalType: &ast.SubrangeType{
+				Low:  asttest.NewConstExpr(asttest.NewString("'a'")),
+				High: asttest.NewConstExpr(asttest.NewString("'z'")),
+			},
+		},
+	)
+
+	runType(t,
+		"Set of Byte",
+		[]rune(`set of Byte`),
+		&ast.SetType{
+			OrdinalType: &ast.OrdIdent{Ident: asttest.NewIdent("Byte")},
+		},
+	)
+
+	runType(t,
+		"Set of enumerated type",
+		[]rune(`set of (Club, Diamond, Heart, Spade)`),
+		&ast.SetType{
+			OrdinalType: ast.EnumeratedType{
+				{Ident: asttest.NewIdent("Club")},
+				{Ident: asttest.NewIdent("Diamond")},
+				{Ident: asttest.NewIdent("Heart")},
+				{Ident: asttest.NewIdent("Spade")},
+			},
+		},
+	)
+
+	runType(t,
+		"Set of Char",
+		[]rune(`set of Char`),
+		&ast.SetType{
+			OrdinalType: &ast.OrdIdent{Ident: asttest.NewIdent("Char")},
+		},
+	)
+}

--- a/parser/parsertest/type_struc_set_test.go
+++ b/parser/parsertest/type_struc_set_test.go
@@ -25,7 +25,7 @@ func TestStrucSet(t *testing.T) {
 		return r
 	}
 
-	runType(t,
+	NewTypeTest(t,
 		"Set with TypeId",
 		[]rune(`set of TSomeInts`),
 		&ast.SetType{
@@ -35,9 +35,9 @@ func TestStrucSet(t *testing.T) {
 			},
 		},
 		tsomeIntsContext,
-	)
+	).Run().RunTypeSection("TIntSet")
 
-	runType(t,
+	NewTypeTest(t,
 		"Set with subrange type",
 		[]rune(`set of 1..250`),
 		&ast.SetType{
@@ -46,9 +46,9 @@ func TestStrucSet(t *testing.T) {
 				High: asttest.NewConstExpr(asttest.NewNumber("250")),
 			},
 		},
-	)
+	).Run().RunTypeSection("TIntSet")
 
-	runType(t,
+	NewTypeTest(t,
 		"Set with a to z",
 		[]rune(`set of 'a'..'z'`),
 		&ast.SetType{
@@ -57,17 +57,17 @@ func TestStrucSet(t *testing.T) {
 				High: asttest.NewConstExpr(asttest.NewString("'z'")),
 			},
 		},
-	)
+	).Run().RunVarSection("MySet")
 
-	runType(t,
+	NewTypeTest(t,
 		"Set of Byte",
 		[]rune(`set of Byte`),
 		&ast.SetType{
 			OrdinalType: &ast.OrdIdent{Ident: asttest.NewIdent("Byte")},
 		},
-	)
+	).Run()
 
-	runType(t,
+	NewTypeTest(t,
 		"Set of enumerated type",
 		[]rune(`set of (Club, Diamond, Heart, Spade)`),
 		&ast.SetType{
@@ -78,13 +78,13 @@ func TestStrucSet(t *testing.T) {
 				{Ident: asttest.NewIdent("Spade")},
 			},
 		},
-	)
+	).Run()
 
-	runType(t,
+	NewTypeTest(t,
 		"Set of Char",
 		[]rune(`set of Char`),
 		&ast.SetType{
 			OrdinalType: &ast.OrdIdent{Ident: asttest.NewIdent("Char")},
 		},
-	)
+	).Run()
 }

--- a/parser/type.go
+++ b/parser/type.go
@@ -86,7 +86,12 @@ func (p *Parser) ParseType() (ast.Type, error) {
 	case token.NumeralInt, token.NumeralReal, token.CharacterString:
 		return p.ParseConstSubrageType()
 	case token.ReservedWord:
-		return p.ParseStringOfStringType()
+		switch t1.Value() {
+		case "PACKED", "ARRAY":
+			return p.ParseStrucType()
+		default:
+			return p.ParseStringOfStringType()
+		}
 	}
 	return nil, p.TokenErrorf("Unsupported Type token %s", t1)
 }

--- a/parser/type.go
+++ b/parser/type.go
@@ -87,7 +87,7 @@ func (p *Parser) ParseType() (ast.Type, error) {
 		return p.ParseConstSubrageType()
 	case token.ReservedWord:
 		switch t1.Value() {
-		case "PACKED", "ARRAY":
+		case "PACKED", "ARRAY", "SET":
 			return p.ParseStrucType()
 		default:
 			return p.ParseStringOfStringType()

--- a/parser/type.go
+++ b/parser/type.go
@@ -23,6 +23,13 @@ func (p *Parser) ParseTypeSection(required bool) (ast.TypeSection, error) {
 		if err != nil {
 			return nil, err
 		}
+		{
+			t := p.CurrentToken()
+			if t.Is(token.ReservedWord) || t.Is(token.EOF) {
+				res = append(res, decl)
+				break
+			}
+		}
 		if _, err := p.Current(token.Symbol(';')); err != nil {
 			return nil, err
 		}

--- a/parser/type_simple.go
+++ b/parser/type_simple.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"github.com/akm/tparser/ast"
 	"github.com/akm/tparser/token"
+	"github.com/pkg/errors"
 )
 
 var realType = token.PredicatorBy("RealType", ast.IsRealTypeName)
@@ -118,4 +119,19 @@ func (p *Parser) ParseEnumeratedTypeElement() (*ast.EnumeratedTypeElement, error
 		return nil, err
 	}
 	return res, nil
+}
+
+func (p *Parser) ParseTypeAsOrdinalType() (ast.OrdinalType, error) {
+	t0 := p.CurrentToken()
+	typ, err := p.ParseType()
+	if err != nil {
+		return nil, err
+	}
+	if ordinalType, ok := typ.(ast.OrdinalType); !ok {
+		return nil, errors.Errorf("Expected OrdinalType, got %T at %s", typ, p.PlaceString(t0))
+	} else if !ordinalType.IsOrdinalType() {
+		return nil, errors.Errorf("Expected OrdinalType, got %T at %s", typ, p.PlaceString(t0))
+	} else {
+		return ordinalType, nil
+	}
 }

--- a/parser/type_struc.go
+++ b/parser/type_struc.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"github.com/akm/tparser/ast"
 	"github.com/akm/tparser/token"
+	"github.com/pkg/errors"
 )
 
 func (p *Parser) ParseStrucType() (ast.StrucType, error) {
@@ -39,13 +40,20 @@ func (p *Parser) ParseArrayType() (*ast.ArrayType, error) {
 
 	if p.CurrentToken().Is(token.Symbol('[')) {
 		p.NextToken()
-		indexes := []ast.Type{}
+		indexes := []ast.OrdinalType{}
 		if err := p.Until(token.Symbol(']'), token.Symbol(','), func() error {
+			t0 := p.CurrentToken()
 			typ, err := p.ParseType()
 			if err != nil {
 				return err
 			}
-			indexes = append(indexes, typ)
+			if ordinalType, ok := typ.(ast.OrdinalType); !ok {
+				return errors.Errorf("Expected OrdinalType, got %T at %s", typ, p.PlaceString(t0))
+			} else if !ordinalType.IsOrdinalType() {
+				return errors.Errorf("Expected OrdinalType, got %T at %s", typ, p.PlaceString(t0))
+			} else {
+				indexes = append(indexes, ordinalType)
+			}
 			return nil
 		}); err != nil {
 			return nil, err

--- a/parser/type_struc.go
+++ b/parser/type_struc.go
@@ -3,7 +3,6 @@ package parser
 import (
 	"github.com/akm/tparser/ast"
 	"github.com/akm/tparser/token"
-	"github.com/pkg/errors"
 )
 
 func (p *Parser) ParseStrucType() (ast.StrucType, error) {
@@ -51,18 +50,11 @@ func (p *Parser) ParseArrayType() (*ast.ArrayType, error) {
 		p.NextToken()
 		indexes := []ast.OrdinalType{}
 		if err := p.Until(token.Symbol(']'), token.Symbol(','), func() error {
-			t0 := p.CurrentToken()
-			typ, err := p.ParseType()
+			ordinalType, err := p.ParseTypeAsOrdinalType()
 			if err != nil {
 				return err
 			}
-			if ordinalType, ok := typ.(ast.OrdinalType); !ok {
-				return errors.Errorf("Expected OrdinalType, got %T at %s", typ, p.PlaceString(t0))
-			} else if !ordinalType.IsOrdinalType() {
-				return errors.Errorf("Expected OrdinalType, got %T at %s", typ, p.PlaceString(t0))
-			} else {
-				indexes = append(indexes, ordinalType)
-			}
+			indexes = append(indexes, ordinalType)
 			return nil
 		}); err != nil {
 			return nil, err
@@ -104,17 +96,10 @@ func (p *Parser) ParseSetType() (*ast.SetType, error) {
 	}
 	p.NextToken()
 
-	t0 := p.CurrentToken()
-	typ, err := p.ParseType()
+	ordinalType, err := p.ParseTypeAsOrdinalType()
 	if err != nil {
 		return nil, err
 	}
-	if ordinalType, ok := typ.(ast.OrdinalType); !ok {
-		return nil, errors.Errorf("Expected OrdinalType, got %T at %s", typ, p.PlaceString(t0))
-	} else if !ordinalType.IsOrdinalType() {
-		return nil, errors.Errorf("Expected OrdinalType, got %T at %s", typ, p.PlaceString(t0))
-	} else {
-		r.OrdinalType = ordinalType
-	}
+	r.OrdinalType = ordinalType
 	return r, nil
 }

--- a/parser/type_struc.go
+++ b/parser/type_struc.go
@@ -1,0 +1,73 @@
+package parser
+
+import (
+	"github.com/akm/tparser/ast"
+	"github.com/akm/tparser/token"
+)
+
+func (p *Parser) ParseStrucType() (ast.StrucType, error) {
+	packed := false
+	if p.CurrentToken().Is(token.ReservedWord.HasKeyword("PACKED")) {
+		packed = true
+		p.NextToken()
+	}
+	switch p.CurrentToken().Value() {
+	case "ARRAY":
+		r, err := p.ParseArrayType()
+		if err != nil {
+			return nil, err
+		}
+		if !r.Packed && packed {
+			r.Packed = packed
+		}
+		return r, nil
+	default:
+		return nil, p.TokenErrorf("Unsupported StrucType token %s", p.CurrentToken())
+	}
+}
+
+func (p *Parser) ParseArrayType() (*ast.ArrayType, error) {
+	r := &ast.ArrayType{Packed: false}
+	if p.CurrentToken().Is(token.ReservedWord.HasKeyword("PACKED")) {
+		r.Packed = true
+		p.NextToken()
+	}
+	if _, err := p.Current(token.ReservedWord.HasKeyword("ARRAY")); err != nil {
+		return nil, p.TokenErrorf("Expected ARRAY, got %s", p.CurrentToken())
+	}
+	p.NextToken()
+
+	if p.CurrentToken().Is(token.Symbol('[')) {
+		p.NextToken()
+		indexes := []ast.Type{}
+		if err := p.Until(token.Symbol(']'), token.Symbol(','), func() error {
+			typ, err := p.ParseType()
+			if err != nil {
+				return err
+			}
+			indexes = append(indexes, typ)
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+		r.IndexTypes = indexes
+		p.NextToken()
+	}
+	if _, err := p.Current(token.ReservedWord.HasKeyword("OF")); err != nil {
+		return nil, p.TokenErrorf("Expected OF, got %s", p.CurrentToken())
+	}
+	p.NextToken()
+
+	baseType, err := p.ParseType()
+	if err != nil {
+		return nil, err
+	}
+	r.BaseType = baseType
+
+	if p.NextToken().Is(token.ReservedWord.HasKeyword("PACKED")) {
+		r.Packed = true
+		p.NextToken()
+	}
+
+	return r, nil
+}

--- a/parser/var.go
+++ b/parser/var.go
@@ -23,6 +23,13 @@ func (p *Parser) ParseVarSection(required bool) (ast.VarSection, error) {
 		if err != nil {
 			return nil, err
 		}
+		{
+			t := p.CurrentToken()
+			if t.Is(token.ReservedWord) || t.Is(token.EOF) {
+				res = append(res, decl)
+				break
+			}
+		}
 		if _, err := p.Current(token.Symbol(';')); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- TypeId implements OrdinalType for array index and set element
- [✨ Consider EOF at the end of section](https://github.com/akm/tparser/commit/d7fe213ef4113e439dfcfa2f47bf3e0f6a96677c)
- Define `TypeTest` to run test for type with TypeSection or VarSection
