### PR TITLE
Features/struc rec type references

### DIFF
--- a/ast/asttest/assert_const.go
+++ b/ast/asttest/assert_const.go
@@ -37,3 +37,15 @@ func AssertConstantDecl(t *testing.T, expected, actual *ast.ConstantDecl) {
 func AssertConstExpr(t *testing.T, expected, actual *ast.ConstExpr) {
 	AssertExpression(t, expected, actual)
 }
+
+func AssertConstExprs(t *testing.T, expected, actual ast.ConstExprs) {
+	if !assert.Equal(t, len(expected), len(actual)) {
+		return
+	}
+	for i, exp := range expected {
+		act := actual[i]
+		if !assert.Equal(t, exp, act) {
+			AssertConstExpr(t, exp, act)
+		}
+	}
+}

--- a/ast/asttest/assert_type.go
+++ b/ast/asttest/assert_type.go
@@ -40,8 +40,8 @@ func AssertType(t *testing.T, expected, actual ast.Type) {
 		AssertTypeId(t, exp, actual.(*ast.TypeId))
 	case ast.SimpleType:
 		AssertSimpleType(t, exp, actual.(ast.SimpleType))
-	// case *ast.StructType:
-	// 	AssertStructType(t, exp, actual.(*ast.StructType))
+	case ast.StrucType:
+		AssertStrucType(t, exp, actual.(ast.StrucType))
 	// case *ast.PointerType:
 	// 	AssertPointerType(t, exp, actual.(*ast.PointerType))
 	case *ast.StringType:

--- a/ast/asttest/assert_type_simple.go
+++ b/ast/asttest/assert_type_simple.go
@@ -27,6 +27,18 @@ func AssertRealType(t *testing.T, expected, actual *ast.RealType) {
 	}
 }
 
+func AssertOrdinalTypes(t *testing.T, expected, actual []ast.OrdinalType) {
+	if !assert.Equal(t, len(expected), len(actual)) {
+		return
+	}
+	for i, exp := range expected {
+		act := actual[i]
+		if !assert.Equal(t, exp, act) {
+			AssertOrdinalType(t, exp, act)
+		}
+	}
+}
+
 func AssertOrdinalType(t *testing.T, expected, actual ast.OrdinalType) {
 	if !assert.IsType(t, expected, actual) {
 		return

--- a/ast/asttest/assert_type_struc.go
+++ b/ast/asttest/assert_type_struc.go
@@ -1,0 +1,120 @@
+package asttest
+
+import (
+	"testing"
+
+	"github.com/akm/tparser/ast"
+	"github.com/stretchr/testify/assert"
+)
+
+func AssertStrucType(t *testing.T, expected, actual ast.StrucType) {
+	if !assert.IsType(t, expected, actual) {
+		return
+	}
+	switch exp := expected.(type) {
+	case *ast.ArrayType:
+		AssertArrayType(t, exp, actual.(*ast.ArrayType))
+	case *ast.SetType:
+		AssertSetType(t, exp, actual.(*ast.SetType))
+	case *ast.FileType:
+		AssertFileType(t, exp, actual.(*ast.FileType))
+	case *ast.RecType:
+		AssertRecType(t, exp, actual.(*ast.RecType))
+	default:
+		assert.Fail(t, "unexpected type: %T", exp)
+	}
+}
+
+func AssertArrayType(t *testing.T, expected, actual *ast.ArrayType) {
+	if !assert.Equal(t, expected.IndexTypes, actual.IndexTypes) {
+		AssertOrdinalTypes(t, expected.IndexTypes, actual.IndexTypes)
+	}
+	if !assert.Equal(t, expected.BaseType, actual.BaseType) {
+		AssertType(t, expected.BaseType, actual.BaseType)
+	}
+	assert.Equal(t, expected.Packed, actual.Packed)
+}
+
+func AssertSetType(t *testing.T, expected, actual *ast.SetType) {
+	if !assert.Equal(t, expected.OrdinalType, actual.OrdinalType) {
+		AssertOrdinalType(t, expected.OrdinalType, actual.OrdinalType)
+	}
+	assert.Equal(t, expected.Packed, actual.Packed)
+}
+
+func AssertFileType(t *testing.T, expected, actual *ast.FileType) {
+	if !assert.Equal(t, expected.TypeId, actual.TypeId) {
+		AssertTypeId(t, expected.TypeId, actual.TypeId)
+	}
+	assert.Equal(t, expected.Packed, actual.Packed)
+}
+
+func AssertRecType(t *testing.T, expected, actual *ast.RecType) {
+	if !assert.Equal(t, expected.FieldList, actual.FieldList) {
+		AssertFieldList(t, expected.FieldList, actual.FieldList)
+	}
+	assert.Equal(t, expected.Packed, actual.Packed)
+}
+
+func AssertFieldList(t *testing.T, expected, actual *ast.FieldList) {
+	if !assert.Equal(t, expected.FieldDecls, actual.FieldDecls) {
+		AssertFieldDecls(t, expected.FieldDecls, actual.FieldDecls)
+	}
+	if !assert.Equal(t, expected.VariantSection, actual.VariantSection) {
+		AssertVariantSection(t, expected.VariantSection, actual.VariantSection)
+	}
+}
+
+func AssertFieldDecls(t *testing.T, expected, actual ast.FieldDecls) {
+	if !assert.Equal(t, len(expected), len(actual)) {
+		return
+	}
+	for i, exp := range expected {
+		act := actual[i]
+		if !assert.Equal(t, exp, act) {
+			AssertFieldDecl(t, exp, act)
+		}
+	}
+}
+
+func AssertFieldDecl(t *testing.T, expected, actual *ast.FieldDecl) {
+	if !assert.Equal(t, expected.IdentList, actual.IdentList) {
+		AssertIdentList(t, expected.IdentList, actual.IdentList)
+	}
+	if !assert.Equal(t, expected.Type, actual.Type) {
+		AssertType(t, expected.Type, actual.Type)
+	}
+}
+
+func AssertVariantSection(t *testing.T, expected, actual *ast.VariantSection) {
+	if !assert.Equal(t, expected.Ident, actual.Ident) {
+		AssertIdent(t, expected.Ident, actual.Ident)
+	}
+	if !assert.Equal(t, expected.TypeId, actual.TypeId) {
+		AssertOrdinalType(t, expected.TypeId, actual.TypeId)
+	}
+	if !assert.Equal(t, expected.RecVariants, actual.RecVariants) {
+		AssertRecVariants(t, expected.RecVariants, actual.RecVariants)
+	}
+}
+
+func AssertRecVariants(t *testing.T, expected, actual ast.RecVariants) {
+	if !assert.Equal(t, len(expected), len(actual)) {
+		return
+	}
+	for i, exp := range expected {
+		act := actual[i]
+		if !assert.Equal(t, exp, act) {
+			AssertRecVariant(t, exp, act)
+		}
+	}
+}
+
+func AssertRecVariant(t *testing.T, expected, actual *ast.RecVariant) {
+	if !assert.Equal(t, expected.ConstExprs, actual.ConstExprs) {
+		AssertConstExprs(t, expected.ConstExprs, actual.ConstExprs)
+	}
+	if !assert.Equal(t, expected.FieldList, actual.FieldList) {
+		AssertFieldList(t, expected.FieldList, actual.FieldList)
+	}
+}

--- a/parser/parsertest/type_section_test_runner.go
+++ b/parser/parsertest/type_section_test_runner.go
@@ -37,7 +37,9 @@ func (tt *TypeSectionTest) Run() *TypeSectionTest {
 		res, err := p.ParseTypeSection(true)
 		if assert.NoError(t, err) {
 			asttest.ClearLocations(t, res)
-			assert.Equal(t, tt.expected, res)
+			if !assert.Equal(t, tt.expected, res) {
+				asttest.AssertTypeSection(t, tt.expected, res)
+			}
 		}
 	})
 	return tt

--- a/parser/parsertest/type_struc_rec_test.go
+++ b/parser/parsertest/type_struc_rec_test.go
@@ -198,6 +198,15 @@ end
 		},
 	).Run().RunTypeSection("TPerson")
 
+	declRectangle := &ast.EnumeratedTypeElement{Ident: asttest.NewIdent("Rectangle")}
+	declTriangle := &ast.EnumeratedTypeElement{Ident: asttest.NewIdent("Triangle")}
+	declCircle := &ast.EnumeratedTypeElement{Ident: asttest.NewIdent("Circle")}
+	declEllipse := &ast.EnumeratedTypeElement{Ident: asttest.NewIdent("Ellipse")}
+	declOther := &ast.EnumeratedTypeElement{Ident: asttest.NewIdent("Other")}
+	declTShapeList := &ast.TypeDecl{
+		Ident: asttest.NewIdent("TShapeList"),
+		Type:  ast.EnumeratedType{declRectangle, declTriangle, declCircle, declEllipse, declOther},
+	}
 	NewTypeSectionTest(t,
 		"with TShapeList",
 		[]rune(`
@@ -212,59 +221,61 @@ type
 	end;
 `),
 		ast.TypeSection{
-			{
-				Ident: asttest.NewIdent("TShapeList"),
-				Type: ast.EnumeratedType{
-					{Ident: asttest.NewIdent("Club")},
-					{Ident: asttest.NewIdent("Diamond")},
-					{Ident: asttest.NewIdent("Heart")},
-					{Ident: asttest.NewIdent("Spade")},
-				},
-			},
+			declTShapeList,
 			{
 				Ident: asttest.NewIdent("TFigure"),
 				Type: &ast.RecType{
 					FieldList: &ast.FieldList{
+						FieldDecls: ast.FieldDecls{},
 						VariantSection: &ast.VariantSection{
-							TypeId: &ast.TypeId{Ident: asttest.NewIdent("TShapeList")},
+							TypeId: &ast.TypeId{
+								Ident: asttest.NewIdent("TShapeList"),
+								Ref:   declTShapeList.ToDeclarations()[0],
+							},
 							RecVariants: ast.RecVariants{
 								{
-									ConstExprs: ast.ConstExprs{asttest.NewConstExpr(&ast.ValueFactor{Value: "Rectangle"})},
+									ConstExprs: ast.ConstExprs{
+										asttest.NewConstExpr(ast.NewDesignator(asttest.NewIdentRef("Rectangle", declRectangle.ToDeclarations()[0]))),
+									},
 									FieldList: &ast.FieldList{
 										FieldDecls: ast.FieldDecls{
 											{
 												IdentList: asttest.NewIdentList("Height", "Width"),
-												Type:      &ast.RealType{Ident: asttest.NewIdent("REAL")},
-											},
-										},
-									},
-								},
-								{
-									ConstExprs: ast.ConstExprs{asttest.NewConstExpr(&ast.ValueFactor{Value: "Triangle"})},
-									FieldList: &ast.FieldList{
-										FieldDecls: ast.FieldDecls{
-											{
-												IdentList: asttest.NewIdentList("Side1", "Side2", "Angle"),
-												Type:      &ast.RealType{Ident: asttest.NewIdent("REAL")},
-											},
-										},
-									},
-								},
-								{
-									ConstExprs: ast.ConstExprs{asttest.NewConstExpr(&ast.ValueFactor{Value: "Circle"})},
-									FieldList: &ast.FieldList{
-										FieldDecls: ast.FieldDecls{
-											{
-												IdentList: asttest.NewIdentList("Radius"),
-												Type:      &ast.RealType{Ident: asttest.NewIdent("REAL")},
+												Type:      &ast.RealType{Ident: asttest.NewIdent("Real")},
 											},
 										},
 									},
 								},
 								{
 									ConstExprs: ast.ConstExprs{
-										asttest.NewConstExpr(&ast.ValueFactor{Value: "Ellipse"}),
-										asttest.NewConstExpr(&ast.ValueFactor{Value: "Other"}),
+										asttest.NewConstExpr(ast.NewDesignator(asttest.NewIdentRef("Triangle", declTriangle.ToDeclarations()[0]))),
+									},
+									FieldList: &ast.FieldList{
+										FieldDecls: ast.FieldDecls{
+											{
+												IdentList: asttest.NewIdentList("Side1", "Side2", "Angle"),
+												Type:      &ast.RealType{Ident: asttest.NewIdent("Real")},
+											},
+										},
+									},
+								},
+								{
+									ConstExprs: ast.ConstExprs{
+										asttest.NewConstExpr(ast.NewDesignator(asttest.NewIdentRef("Circle", declCircle.ToDeclarations()[0]))),
+									},
+									FieldList: &ast.FieldList{
+										FieldDecls: ast.FieldDecls{
+											{
+												IdentList: asttest.NewIdentList("Radius"),
+												Type:      &ast.RealType{Ident: asttest.NewIdent("Real")},
+											},
+										},
+									},
+								},
+								{
+									ConstExprs: ast.ConstExprs{
+										asttest.NewConstExpr(ast.NewDesignator(asttest.NewIdentRef("Ellipse", declEllipse.ToDeclarations()[0]))),
+										asttest.NewConstExpr(ast.NewDesignator(asttest.NewIdentRef("Other", declOther.ToDeclarations()[0]))),
 									},
 									FieldList: &ast.FieldList{
 										FieldDecls: ast.FieldDecls{},
@@ -276,5 +287,5 @@ type
 				},
 			},
 		},
-	)
+	).Run()
 }


### PR DESCRIPTION
- Fix test added in #51 
    - Run method of test with TShapeList were not called
    - [💚 Fix test with TShapeList](https://github.com/akm/tparser/commit/517132c728176f9b87c0e29ffccc55ebebc67641)
- [💚 Define Assert functions for StrucType](https://github.com/akm/tparser/commit/13246d27d45e24a76e544e11c4c21ccd60e2be76)