### PR TITLE
Use typeid for named types

### DIFF
--- a/ast/asttest/assert_type.go
+++ b/ast/asttest/assert_type.go
@@ -44,8 +44,8 @@ func AssertType(t *testing.T, expected, actual ast.Type) {
 		AssertStrucType(t, exp, actual.(ast.StrucType))
 	// case *ast.PointerType:
 	// 	AssertPointerType(t, exp, actual.(*ast.PointerType))
-	case *ast.StringType:
-		AssertStringType(t, exp, actual.(*ast.StringType))
+	case ast.StringType:
+		AssertStringType(t, exp, actual.(ast.StringType))
 	// case *ast.ProcedureType:
 	// 	AssertProcedureType(t, exp, actual.(*ast.ProcedureType))
 	// case *ast.VariantType:

--- a/ast/asttest/assert_type_embedded.go
+++ b/ast/asttest/assert_type_embedded.go
@@ -1,0 +1,15 @@
+package asttest
+
+import (
+	"testing"
+
+	"github.com/akm/tparser/ast"
+	"github.com/stretchr/testify/assert"
+)
+
+func AssertTypeEmbedded(t *testing.T, expected, actual *ast.TypeEmbedded) {
+	if !assert.Equal(t, expected.Ident, actual.Ident) {
+		AssertIdent(t, expected.Ident, actual.Ident)
+	}
+	assert.Equal(t, expected.Kind, actual.Kind)
+}

--- a/ast/asttest/assert_type_simple.go
+++ b/ast/asttest/assert_type_simple.go
@@ -52,8 +52,8 @@ func AssertOrdinalType(t *testing.T, expected, actual ast.OrdinalType) {
 		return
 	}
 	switch exp := expected.(type) {
-	case *ast.OrdIdent:
-		AssertOrdIdent(t, exp, actual.(*ast.OrdIdent))
+	case ast.OrdIdent:
+		AssertOrdIdent(t, exp, actual.(ast.OrdIdent))
 	case ast.EnumeratedType:
 		AssertEnumeratedType(t, exp, actual.(ast.EnumeratedType))
 	case *ast.SubrangeType:
@@ -63,9 +63,17 @@ func AssertOrdinalType(t *testing.T, expected, actual ast.OrdinalType) {
 	}
 }
 
-func AssertOrdIdent(t *testing.T, expected, actual *ast.OrdIdent) {
-	if !assert.Equal(t, expected.Ident, actual.Ident) {
-		AssertIdent(t, expected.Ident, actual.Ident)
+func AssertOrdIdent(t *testing.T, expected, actual ast.OrdIdent) {
+	if !assert.IsType(t, expected, actual) {
+		return
+	}
+	switch exp := expected.(type) {
+	case *ast.TypeEmbedded:
+		AssertTypeEmbedded(t, exp, actual.(*ast.TypeEmbedded))
+	case *ast.TypeId:
+		AssertTypeId(t, exp, actual.(*ast.TypeId))
+	default:
+		assert.Fail(t, "unexpected type: %T", exp)
 	}
 }
 

--- a/ast/asttest/assert_type_simple.go
+++ b/ast/asttest/assert_type_simple.go
@@ -12,8 +12,8 @@ func AssertSimpleType(t *testing.T, expected, actual ast.SimpleType) {
 		return
 	}
 	switch exp := expected.(type) {
-	case *ast.RealType:
-		AssertRealType(t, exp, actual.(*ast.RealType))
+	case ast.RealType:
+		AssertRealType(t, exp, actual.(ast.RealType))
 	case ast.OrdinalType:
 		AssertOrdinalType(t, exp, actual.(ast.OrdinalType))
 	default:
@@ -21,9 +21,17 @@ func AssertSimpleType(t *testing.T, expected, actual ast.SimpleType) {
 	}
 }
 
-func AssertRealType(t *testing.T, expected, actual *ast.RealType) {
-	if !assert.Equal(t, expected.Ident, actual.Ident) {
-		AssertIdent(t, expected.Ident, actual.Ident)
+func AssertRealType(t *testing.T, expected, actual ast.RealType) {
+	if !assert.IsType(t, expected, actual) {
+		return
+	}
+	switch exp := expected.(type) {
+	case *ast.TypeEmbedded:
+		AssertTypeEmbedded(t, exp, actual.(*ast.TypeEmbedded))
+	case *ast.TypeId:
+		AssertTypeId(t, exp, actual.(*ast.TypeId))
+	default:
+		assert.Fail(t, "unexpected type: %T", exp)
 	}
 }
 

--- a/ast/asttest/assert_type_string.go
+++ b/ast/asttest/assert_type_string.go
@@ -7,9 +7,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func AssertStringType(t *testing.T, expected, actual *ast.StringType) {
-	assert.Equal(t, expected.Name, actual.Name)
-	if !assert.Equal(t, expected.Name, actual.Name) {
-		AssertConstExpr(t, expected.Length, actual.Length)
+func AssertStringType(t *testing.T, expected, actual ast.StringType) {
+	if !assert.IsType(t, expected, actual) {
+		return
 	}
+	switch exp := expected.(type) {
+	case *ast.TypeEmbedded:
+		AssertTypeEmbedded(t, exp, actual.(*ast.TypeEmbedded))
+	case *ast.TypeId:
+		AssertTypeId(t, exp, actual.(*ast.TypeId))
+	case *ast.FixedStringType:
+		AssertFixedStringType(t, exp, actual.(*ast.FixedStringType))
+	default:
+		assert.Fail(t, "unexpected type: %T", exp)
+	}
+}
+
+func AssertFixedStringType(t *testing.T, expected, actual *ast.FixedStringType) {
+	if !assert.Equal(t, expected.StringType, actual.StringType) {
+		AssertStringType(t, expected.StringType, actual.StringType)
+	}
+	AssertConstExpr(t, expected.Length, actual.Length)
 }

--- a/ast/asttest/type_simple.go
+++ b/ast/asttest/type_simple.go
@@ -13,7 +13,7 @@ func NewRealType(name interface{}) ast.RealType {
 	}
 }
 
-func NewOrdIdent(name interface{}) *ast.OrdIdent {
+func NewOrdIdent(name interface{}) ast.OrdIdent {
 	switch v := name.(type) {
 	case string:
 		return ast.NewOrdIdent(NewIdent(v))

--- a/ast/asttest/type_simple.go
+++ b/ast/asttest/type_simple.go
@@ -4,10 +4,10 @@ import (
 	"github.com/akm/tparser/ast"
 )
 
-func NewRealType(name interface{}) *ast.RealType {
+func NewRealType(name interface{}) ast.RealType {
 	switch v := name.(type) {
 	case string:
-		return ast.NewRealType(*NewIdent(v))
+		return ast.NewRealType(NewIdent(v))
 	default:
 		return ast.NewRealType(name)
 	}

--- a/ast/asttest/type_string.go
+++ b/ast/asttest/type_string.go
@@ -4,6 +4,10 @@ import (
 	"github.com/akm/tparser/ast"
 )
 
-func NewStringType(name string, args ...interface{}) *ast.StringType {
-	return ast.NewStringType(name, args...)
+func NewStringType(name interface{}) ast.StringType {
+	return ast.NewStringType(NewIdent(name))
+}
+
+func NewFixedStringType(name interface{}, length *ast.ConstExpr) *ast.FixedStringType {
+	return ast.NewFixedStringType(NewIdent(name), length)
 }

--- a/ast/type.go
+++ b/ast/type.go
@@ -2,7 +2,6 @@ package ast
 
 import (
 	"github.com/akm/tparser/ast/astcore"
-	"github.com/pkg/errors"
 )
 
 // - TypeSection
@@ -78,82 +77,4 @@ func (m *TypeDecl) ToDeclarations() astcore.Decls {
 type Type interface {
 	Node
 	isType()
-}
-
-// - TypeId
-//   ```
-//   [UnitId '.'] <type-identifier>
-//   ```
-type TypeId struct {
-	Type
-	UnitId *UnitId
-	Ident  *Ident
-	Ref    *astcore.Decl // Actual Type object
-}
-
-func NewTypeId(unitIdOrIdent interface{}, args ...interface{}) *TypeId {
-	var ref *astcore.Decl
-	if len(args) > 0 {
-		if v, ok := args[len(args)-1].(*astcore.Decl); ok {
-			ref = v
-			args = args[:len(args)-1]
-		}
-	}
-	if len(args) == 0 {
-		return &TypeId{Ident: NewIdentFrom(unitIdOrIdent), Ref: ref}
-	} else if len(args) == 1 {
-		return &TypeId{
-			UnitId: NewUnitId(unitIdOrIdent),
-			Ident:  NewIdentFrom(args[0]),
-			Ref:    ref,
-		}
-	} else {
-		panic(errors.Errorf("too many arguments for NewTypeId: %v, %v", unitIdOrIdent, args))
-	}
-}
-
-func (m *TypeId) Children() Nodes {
-	r := Nodes{}
-	if m.UnitId != nil {
-		r = append(r, m.UnitId)
-	}
-	r = append(r, m.Ident)
-	return r
-}
-
-func (*TypeId) isType() {}
-func (m *TypeId) IsSimpleType() bool {
-	if m.Ref == nil {
-		return false
-	}
-	if m.Ref.Node == nil {
-		return false
-	}
-	decl, ok := m.Ref.Node.(*TypeDecl)
-	if !ok {
-		return false
-	}
-	simpleType, ok := decl.Type.(SimpleType)
-	if !ok {
-		return false
-	}
-	return simpleType.IsSimpleType()
-}
-
-func (m *TypeId) IsOrdinalType() bool {
-	if m.Ref == nil {
-		return false
-	}
-	if m.Ref.Node == nil {
-		return false
-	}
-	decl, ok := m.Ref.Node.(*TypeDecl)
-	if !ok {
-		return false
-	}
-	ordinalType, ok := decl.Type.(OrdinalType)
-	if !ok {
-		return false
-	}
-	return ordinalType.IsOrdinalType()
 }

--- a/ast/type_embedded.go
+++ b/ast/type_embedded.go
@@ -1,0 +1,101 @@
+package ast
+
+import (
+	"strings"
+
+	"github.com/akm/tparser/ast/astcore"
+)
+
+type EmbeddedTypeKind int
+
+const (
+	EtkReal EmbeddedTypeKind = iota + 1
+	EtkOrdIdent
+	EtkString
+)
+
+type TypeEmbedded struct {
+	Kind  EmbeddedTypeKind
+	Ident *Ident
+	// implements
+	Type
+	SimpleType
+	OrdinalType
+}
+
+func newTypeEmbedded(kind EmbeddedTypeKind, name string) *TypeEmbedded {
+	return &TypeEmbedded{
+		Kind: kind,
+		Ident: &astcore.Ident{
+			Name:     name,
+			Location: &astcore.Location{Path: "embedded"},
+		},
+	}
+}
+
+func (m *TypeEmbedded) Children() Nodes {
+	return Nodes{m.Ident}
+}
+
+func (*TypeEmbedded) isType() {}
+func (m *TypeEmbedded) IsSimpleType() bool {
+	return m.IsRealType() || m.IsOrdIdent()
+}
+func (m *TypeEmbedded) IsRealType() bool {
+	return m.Kind == EtkReal
+}
+
+func (m *TypeEmbedded) IsOrdinalType() bool {
+	return m.IsOrdIdent()
+}
+
+func (m *TypeEmbedded) IsOrdIdent() bool {
+	return m.Kind == EtkOrdIdent
+}
+
+func (m *TypeEmbedded) IsStringType() bool {
+	return m.Kind == EtkString
+}
+
+var embeddedTypeDeclMap = map[string]*TypeDecl{}
+
+func newEmbeddedTypeDecl(kind EmbeddedTypeKind, name string) *TypeDecl {
+	typ := newTypeEmbedded(kind, name)
+	r := &TypeDecl{Ident: typ.Ident, Type: typ}
+	embeddedTypeDeclMap[strings.ToUpper(typ.Ident.Name)] = r
+	return r
+}
+
+func EmbeddedTypeDecl(name string) *TypeDecl {
+	return embeddedTypeDeclMap[strings.ToUpper(name)]
+}
+
+var (
+	EmbeddedReal48   = newEmbeddedTypeDecl(EtkReal, "Real48")
+	EmbeddedReal     = newEmbeddedTypeDecl(EtkReal, "Real")
+	EmbeddedSingile  = newEmbeddedTypeDecl(EtkReal, "Single")
+	EmbeddedDouble   = newEmbeddedTypeDecl(EtkReal, "Double")
+	EmbeddedExtended = newEmbeddedTypeDecl(EtkReal, "Extended")
+	EmbeddedCurrency = newEmbeddedTypeDecl(EtkReal, "Currency")
+	EmbeddedComp     = newEmbeddedTypeDecl(EtkReal, "Comp")
+
+	EmbeddedInteger  = newEmbeddedTypeDecl(EtkOrdIdent, "Integer")
+	EmbeddedCardinal = newEmbeddedTypeDecl(EtkOrdIdent, "Cardinal")
+	EmbeddedShortInt = newEmbeddedTypeDecl(EtkOrdIdent, "ShortInt")
+	EmbeddedSmallInt = newEmbeddedTypeDecl(EtkOrdIdent, "SmallInt")
+	EmbeddedLongInt  = newEmbeddedTypeDecl(EtkOrdIdent, "LongInt")
+	EmbeddedInt64    = newEmbeddedTypeDecl(EtkOrdIdent, "Int64")
+	EmbeddedByte     = newEmbeddedTypeDecl(EtkOrdIdent, "Byte")
+	EmbeddedWord     = newEmbeddedTypeDecl(EtkOrdIdent, "Word")
+	EmbeddedLongWord = newEmbeddedTypeDecl(EtkOrdIdent, "LongWord")
+	EmbeddedChar     = newEmbeddedTypeDecl(EtkOrdIdent, "Char")
+	EmbeddedAnsiChar = newEmbeddedTypeDecl(EtkOrdIdent, "AnsiChar")
+	EmbeddedWideChar = newEmbeddedTypeDecl(EtkOrdIdent, "WideChar")
+	EmbeddedBoolean  = newEmbeddedTypeDecl(EtkOrdIdent, "Boolean")
+
+	EmbeddedString     = newEmbeddedTypeDecl(EtkString, "String")
+	EmbeddedAnsiString = newEmbeddedTypeDecl(EtkString, "AnsiString")
+	EmbeddedWideString = newEmbeddedTypeDecl(EtkString, "WideString")
+
+	// TODO Define Embedded Pointer Types PChar, PInteger, PByteArray, etc.
+)

--- a/ast/type_embedded.go
+++ b/ast/type_embedded.go
@@ -11,7 +11,7 @@ type EmbeddedTypeKind int
 const (
 	EtkReal EmbeddedTypeKind = iota + 1
 	EtkOrdIdent
-	EtkString
+	EtkStringType
 )
 
 type TypeEmbedded struct {
@@ -54,12 +54,12 @@ func (m *TypeEmbedded) IsOrdIdent() bool {
 }
 
 func (m *TypeEmbedded) IsStringType() bool {
-	return m.Kind == EtkString
+	return m.Kind == EtkStringType
 }
 
 var embeddedTypeDeclMaps = func() map[EmbeddedTypeKind]map[string]*astcore.Decl {
 	r := make(map[EmbeddedTypeKind]map[string]*astcore.Decl)
-	for _, kind := range []EmbeddedTypeKind{EtkReal, EtkOrdIdent, EtkString} {
+	for _, kind := range []EmbeddedTypeKind{EtkReal, EtkOrdIdent, EtkStringType} {
 		r[kind] = make(map[string]*astcore.Decl)
 	}
 	return r
@@ -101,9 +101,9 @@ var (
 	EmbeddedWideChar = newEmbeddedTypeDecl(EtkOrdIdent, "WideChar")
 	EmbeddedBoolean  = newEmbeddedTypeDecl(EtkOrdIdent, "Boolean")
 
-	EmbeddedString     = newEmbeddedTypeDecl(EtkString, "String")
-	EmbeddedAnsiString = newEmbeddedTypeDecl(EtkString, "AnsiString")
-	EmbeddedWideString = newEmbeddedTypeDecl(EtkString, "WideString")
+	EmbeddedString     = newEmbeddedTypeDecl(EtkStringType, "String")
+	EmbeddedAnsiString = newEmbeddedTypeDecl(EtkStringType, "AnsiString")
+	EmbeddedWideString = newEmbeddedTypeDecl(EtkStringType, "WideString")
 
 	// TODO Define Embedded Pointer Types PChar, PInteger, PByteArray, etc.
 )

--- a/ast/type_embedded.go
+++ b/ast/type_embedded.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/akm/tparser/ast/astcore"
+	"github.com/pkg/errors"
 )
 
 type EmbeddedTypeKind int
@@ -57,17 +58,36 @@ func (m *TypeEmbedded) IsStringType() bool {
 	return m.Kind == EtkString
 }
 
-var embeddedTypeDeclMap = map[string]*TypeDecl{}
+var embeddedRealTypeDeclMap = map[string]*astcore.Decl{}
+var embeddedOrdIdentTypeDeclMap = map[string]*astcore.Decl{}
+var embeddedStringTypeDeclMap = map[string]*astcore.Decl{}
 
 func newEmbeddedTypeDecl(kind EmbeddedTypeKind, name string) *TypeDecl {
 	typ := newTypeEmbedded(kind, name)
-	r := &TypeDecl{Ident: typ.Ident, Type: typ}
-	embeddedTypeDeclMap[strings.ToUpper(typ.Ident.Name)] = r
-	return r
+	typeDecl := &TypeDecl{Ident: typ.Ident, Type: typ}
+	key := strings.ToUpper(typ.Ident.Name)
+	decl := typeDecl.ToDeclarations()[0]
+	switch kind {
+	case EtkReal:
+		embeddedRealTypeDeclMap[key] = decl
+	case EtkOrdIdent:
+		embeddedOrdIdentTypeDeclMap[key] = decl
+	case EtkString:
+		embeddedStringTypeDeclMap[key] = decl
+	default:
+		panic(errors.Errorf("unexpected embedded type kind"))
+	}
+	return typeDecl
 }
 
-func EmbeddedTypeDecl(name string) *TypeDecl {
-	return embeddedTypeDeclMap[strings.ToUpper(name)]
+func EmbeddedRealTypeDecl(name string) *astcore.Decl {
+	return embeddedRealTypeDeclMap[strings.ToUpper(name)]
+}
+func EmbeddedOrdIdentTypeDecl(name string) *astcore.Decl {
+	return embeddedOrdIdentTypeDeclMap[strings.ToUpper(name)]
+}
+func EmbeddedStringTypeDecl(name string) *astcore.Decl {
+	return embeddedStringTypeDeclMap[strings.ToUpper(name)]
 }
 
 var (

--- a/ast/type_embedded.go
+++ b/ast/type_embedded.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/akm/tparser/ast/astcore"
-	"github.com/pkg/errors"
 )
 
 type EmbeddedTypeKind int
@@ -58,36 +57,25 @@ func (m *TypeEmbedded) IsStringType() bool {
 	return m.Kind == EtkString
 }
 
-var embeddedRealTypeDeclMap = map[string]*astcore.Decl{}
-var embeddedOrdIdentTypeDeclMap = map[string]*astcore.Decl{}
-var embeddedStringTypeDeclMap = map[string]*astcore.Decl{}
+var embeddedTypeDeclMaps = func() map[EmbeddedTypeKind]map[string]*astcore.Decl {
+	r := make(map[EmbeddedTypeKind]map[string]*astcore.Decl)
+	for _, kind := range []EmbeddedTypeKind{EtkReal, EtkOrdIdent, EtkString} {
+		r[kind] = make(map[string]*astcore.Decl)
+	}
+	return r
+}()
 
 func newEmbeddedTypeDecl(kind EmbeddedTypeKind, name string) *TypeDecl {
 	typ := newTypeEmbedded(kind, name)
 	typeDecl := &TypeDecl{Ident: typ.Ident, Type: typ}
 	key := strings.ToUpper(typ.Ident.Name)
 	decl := typeDecl.ToDeclarations()[0]
-	switch kind {
-	case EtkReal:
-		embeddedRealTypeDeclMap[key] = decl
-	case EtkOrdIdent:
-		embeddedOrdIdentTypeDeclMap[key] = decl
-	case EtkString:
-		embeddedStringTypeDeclMap[key] = decl
-	default:
-		panic(errors.Errorf("unexpected embedded type kind"))
-	}
+	embeddedTypeDeclMaps[kind][key] = decl
 	return typeDecl
 }
 
-func EmbeddedRealTypeDecl(name string) *astcore.Decl {
-	return embeddedRealTypeDeclMap[strings.ToUpper(name)]
-}
-func EmbeddedOrdIdentTypeDecl(name string) *astcore.Decl {
-	return embeddedOrdIdentTypeDeclMap[strings.ToUpper(name)]
-}
-func EmbeddedStringTypeDecl(name string) *astcore.Decl {
-	return embeddedStringTypeDeclMap[strings.ToUpper(name)]
+func EmbeddedTypeDecl(kind EmbeddedTypeKind, name string) *astcore.Decl {
+	return embeddedTypeDeclMaps[kind][strings.ToUpper(name)]
 }
 
 var (

--- a/ast/type_id.go
+++ b/ast/type_id.go
@@ -46,16 +46,24 @@ func (m *TypeId) Children() Nodes {
 	return r
 }
 
-func (*TypeId) isType() {}
-func (m *TypeId) IsSimpleType() bool {
+func (m *TypeId) getRefNodeDecl() *TypeDecl {
 	if m.Ref == nil {
-		return false
+		return nil
 	}
 	if m.Ref.Node == nil {
-		return false
+		return nil
 	}
 	decl, ok := m.Ref.Node.(*TypeDecl)
 	if !ok {
+		return nil
+	}
+	return decl
+}
+
+func (*TypeId) isType() {}
+func (m *TypeId) IsSimpleType() bool {
+	decl := m.getRefNodeDecl()
+	if decl == nil {
 		return false
 	}
 	simpleType, ok := decl.Type.(SimpleType)
@@ -66,14 +74,8 @@ func (m *TypeId) IsSimpleType() bool {
 }
 
 func (m *TypeId) IsOrdinalType() bool {
-	if m.Ref == nil {
-		return false
-	}
-	if m.Ref.Node == nil {
-		return false
-	}
-	decl, ok := m.Ref.Node.(*TypeDecl)
-	if !ok {
+	decl := m.getRefNodeDecl()
+	if decl == nil {
 		return false
 	}
 	ordinalType, ok := decl.Type.(OrdinalType)
@@ -84,14 +86,8 @@ func (m *TypeId) IsOrdinalType() bool {
 }
 
 func (m *TypeId) IsRealType() bool {
-	if m.Ref == nil {
-		return false
-	}
-	if m.Ref.Node == nil {
-		return false
-	}
-	decl, ok := m.Ref.Node.(*TypeDecl)
-	if !ok {
+	decl := m.getRefNodeDecl()
+	if decl == nil {
 		return false
 	}
 	ordinalType, ok := decl.Type.(RealType)
@@ -102,14 +98,8 @@ func (m *TypeId) IsRealType() bool {
 }
 
 func (m *TypeId) IsOrdIdent() bool {
-	if m.Ref == nil {
-		return false
-	}
-	if m.Ref.Node == nil {
-		return false
-	}
-	decl, ok := m.Ref.Node.(*TypeDecl)
-	if !ok {
+	decl := m.getRefNodeDecl()
+	if decl == nil {
 		return false
 	}
 	ordIdent, ok := decl.Type.(OrdIdent)
@@ -120,14 +110,8 @@ func (m *TypeId) IsOrdIdent() bool {
 }
 
 func (m *TypeId) IsStringType() bool {
-	if m.Ref == nil {
-		return false
-	}
-	if m.Ref.Node == nil {
-		return false
-	}
-	decl, ok := m.Ref.Node.(*TypeDecl)
-	if !ok {
+	decl := m.getRefNodeDecl()
+	if decl == nil {
 		return false
 	}
 	ordIdent, ok := decl.Type.(StringType)

--- a/ast/type_id.go
+++ b/ast/type_id.go
@@ -118,3 +118,21 @@ func (m *TypeId) IsOrdIdent() bool {
 	}
 	return ordIdent.IsOrdIdent()
 }
+
+func (m *TypeId) IsStringType() bool {
+	if m.Ref == nil {
+		return false
+	}
+	if m.Ref.Node == nil {
+		return false
+	}
+	decl, ok := m.Ref.Node.(*TypeDecl)
+	if !ok {
+		return false
+	}
+	ordIdent, ok := decl.Type.(StringType)
+	if !ok {
+		return false
+	}
+	return ordIdent.IsStringType()
+}

--- a/ast/type_id.go
+++ b/ast/type_id.go
@@ -1,0 +1,84 @@
+package ast
+
+import (
+	"github.com/akm/tparser/ast/astcore"
+	"github.com/pkg/errors"
+)
+
+// - TypeId
+//   ```
+//   [UnitId '.'] <type-identifier>
+//   ```
+type TypeId struct {
+	Type
+	UnitId *UnitId
+	Ident  *Ident
+	Ref    *astcore.Decl // Actual Type object
+}
+
+func NewTypeId(unitIdOrIdent interface{}, args ...interface{}) *TypeId {
+	var ref *astcore.Decl
+	if len(args) > 0 {
+		if v, ok := args[len(args)-1].(*astcore.Decl); ok {
+			ref = v
+			args = args[:len(args)-1]
+		}
+	}
+	if len(args) == 0 {
+		return &TypeId{Ident: NewIdentFrom(unitIdOrIdent), Ref: ref}
+	} else if len(args) == 1 {
+		return &TypeId{
+			UnitId: NewUnitId(unitIdOrIdent),
+			Ident:  NewIdentFrom(args[0]),
+			Ref:    ref,
+		}
+	} else {
+		panic(errors.Errorf("too many arguments for NewTypeId: %v, %v", unitIdOrIdent, args))
+	}
+}
+
+func (m *TypeId) Children() Nodes {
+	r := Nodes{}
+	if m.UnitId != nil {
+		r = append(r, m.UnitId)
+	}
+	r = append(r, m.Ident)
+	return r
+}
+
+func (*TypeId) isType() {}
+func (m *TypeId) IsSimpleType() bool {
+	if m.Ref == nil {
+		return false
+	}
+	if m.Ref.Node == nil {
+		return false
+	}
+	decl, ok := m.Ref.Node.(*TypeDecl)
+	if !ok {
+		return false
+	}
+	simpleType, ok := decl.Type.(SimpleType)
+	if !ok {
+		return false
+	}
+	return simpleType.IsSimpleType()
+}
+
+func (m *TypeId) IsOrdinalType() bool {
+	if m.Ref == nil {
+		return false
+	}
+	if m.Ref.Node == nil {
+		return false
+	}
+	decl, ok := m.Ref.Node.(*TypeDecl)
+	if !ok {
+		return false
+	}
+	ordinalType, ok := decl.Type.(OrdinalType)
+	if !ok {
+		return false
+	}
+	return ordinalType.IsOrdinalType()
+}

--- a/ast/type_id.go
+++ b/ast/type_id.go
@@ -100,3 +100,21 @@ func (m *TypeId) IsRealType() bool {
 	}
 	return ordinalType.IsRealType()
 }
+
+func (m *TypeId) IsOrdIdent() bool {
+	if m.Ref == nil {
+		return false
+	}
+	if m.Ref.Node == nil {
+		return false
+	}
+	decl, ok := m.Ref.Node.(*TypeDecl)
+	if !ok {
+		return false
+	}
+	ordIdent, ok := decl.Type.(OrdIdent)
+	if !ok {
+		return false
+	}
+	return ordIdent.IsOrdIdent()
+}

--- a/ast/type_id.go
+++ b/ast/type_id.go
@@ -82,3 +82,21 @@ func (m *TypeId) IsOrdinalType() bool {
 	}
 	return ordinalType.IsOrdinalType()
 }
+
+func (m *TypeId) IsRealType() bool {
+	if m.Ref == nil {
+		return false
+	}
+	if m.Ref.Node == nil {
+		return false
+	}
+	decl, ok := m.Ref.Node.(*TypeDecl)
+	if !ok {
+		return false
+	}
+	ordinalType, ok := decl.Type.(RealType)
+	if !ok {
+		return false
+	}
+	return ordinalType.IsRealType()
+}

--- a/ast/type_simple.go
+++ b/ast/type_simple.go
@@ -50,13 +50,13 @@ func NewRealType(name interface{}) RealType {
 	case RealType:
 		return v
 	case Ident:
-		if decl := EmbeddedRealTypeDecl(v.Name); decl != nil {
+		if decl := EmbeddedTypeDecl(EtkReal, v.Name); decl != nil {
 			return NewTypeId(&v, decl)
 		} else {
 			return NewTypeId(&v)
 		}
 	case *Ident:
-		if decl := EmbeddedRealTypeDecl(v.Name); decl != nil {
+		if decl := EmbeddedTypeDecl(EtkReal, v.Name); decl != nil {
 			return NewTypeId(v, decl)
 		} else {
 			return NewTypeId(v)

--- a/ast/type_simple.go
+++ b/ast/type_simple.go
@@ -1,10 +1,7 @@
 package ast
 
 import (
-	"strings"
-
 	"github.com/akm/tparser/ast/astcore"
-	"github.com/akm/tparser/ext"
 	"github.com/pkg/errors"
 )
 
@@ -114,58 +111,32 @@ type OrdinalType interface {
 //   ```
 //   PCHAR
 //   ```
-func IsOrdIdentName(w string) bool {
-	return ordIdentNames.Include(strings.ToUpper(w))
-}
-
-var ordIdentNames = ext.Strings{
-	// Integer types
-	"INTEGER",
-	"CARDINAL",
-	"SHORTINT",
-	"SMALLINT",
-	"LONGINT",
-	"INT64",
-	"BYTE",
-	"WORD",
-	"LONGWORD",
-
-	// Character types
-	"CHAR",
-	"ANSICHAR",
-	"WIDECHAR",
-
-	// Boolean types
-	"BOOLEAN",
-
-	// The following are in String Type
-	// "PCHAR",
-	// "PANSICHAR",
-	// "PWIDECHAR",
-}.Set()
-
-type OrdIdent struct {
+type OrdIdent interface {
+	IsOrdIdent() bool
+	// implements
 	OrdinalType
-	*Ident
 }
 
-func NewOrdIdent(name interface{}) *OrdIdent {
+func NewOrdIdent(name interface{}) OrdIdent {
 	switch v := name.(type) {
-	case *OrdIdent:
+	case OrdIdent:
 		return v
 	case Ident:
-		return &OrdIdent{Ident: &v}
+		if decl := EmbeddedTypeDecl(EtkOrdIdent, v.Name); decl != nil {
+			return NewTypeId(&v, decl)
+		} else {
+			return NewTypeId(&v)
+		}
 	case *Ident:
-		return &OrdIdent{Ident: v}
+		if decl := EmbeddedTypeDecl(EtkOrdIdent, v.Name); decl != nil {
+			return NewTypeId(v, decl)
+		} else {
+			return NewTypeId(v)
+		}
 	default:
 		panic(errors.Errorf("invalid type %T for NewOrdIndent %+v", name, name))
 	}
 }
-
-func (*OrdIdent) isType()             {}
-func (*OrdIdent) IsSimpleType() bool  { return true }
-func (*OrdIdent) IsOrdinalType() bool { return true }
-func (m *OrdIdent) Children() Nodes   { return Nodes{m.Ident} }
 
 // - EnumeratedType
 //   ```

--- a/ast/type_simple.go
+++ b/ast/type_simple.go
@@ -39,41 +39,32 @@ type SimpleType interface {
 //   ```
 //   COMP
 //   ```
-func IsRealTypeName(w string) bool {
-	return realTypeNames.Include(strings.ToUpper(w))
-}
-
-var realTypeNames = ext.Strings{
-	"REAL48",
-	"REAL",
-	"SINGLE",
-	"DOUBLE",
-	"EXTENDED",
-	"CURRENCY",
-	"COMP",
-}.Set()
-
-type RealType struct {
+type RealType interface {
+	IsRealType() bool
+	// implements
 	SimpleType
-	*Ident
 }
 
-func NewRealType(name interface{}) *RealType {
+func NewRealType(name interface{}) RealType {
 	switch v := name.(type) {
-	case *RealType:
+	case RealType:
 		return v
 	case Ident:
-		return &RealType{Ident: &v}
+		if decl := EmbeddedRealTypeDecl(v.Name); decl != nil {
+			return NewTypeId(&v, decl)
+		} else {
+			return NewTypeId(&v)
+		}
 	case *Ident:
-		return &RealType{Ident: v}
+		if decl := EmbeddedRealTypeDecl(v.Name); decl != nil {
+			return NewTypeId(v, decl)
+		} else {
+			return NewTypeId(v)
+		}
 	default:
 		panic(errors.Errorf("invalid type %T for NewRealType %+v", name, name))
 	}
 }
-
-func (*RealType) isType()            {}
-func (*RealType) IsSimpleType() bool { return true }
-func (m *RealType) Children() Nodes  { return Nodes{m.Ident} }
 
 // - OrdinalType
 //   ```

--- a/ast/type_string.go
+++ b/ast/type_string.go
@@ -1,21 +1,8 @@
 package ast
 
 import (
-	"strings"
-
-	"github.com/akm/tparser/ext"
 	"github.com/pkg/errors"
 )
-
-func IsStringTypeName(w string) bool {
-	return stringTypeNames.Include(strings.ToUpper(w))
-}
-
-var stringTypeNames = ext.Strings{
-	"STRING",
-	"ANSISTRING",
-	"WIDESTRING",
-}.Set()
 
 // - StringType
 //   ```
@@ -30,36 +17,38 @@ var stringTypeNames = ext.Strings{
 //   ```
 //   STRING '[' ConstExpr ']'
 //   ```
-type StringType struct {
+type StringType interface {
+	IsStringType() bool
+	// implements
 	Type
-	Name   string
+}
+
+func NewStringType(name interface{}) StringType {
+	switch v := name.(type) {
+	case StringType:
+		return v
+	case *Ident:
+		if decl := EmbeddedTypeDecl(EtkStringType, v.Name); decl != nil {
+			return NewTypeId(v, decl)
+		} else {
+			return NewTypeId(v)
+		}
+	default:
+		panic(errors.Errorf("invalid type %T for NewStringType %+v", name, name))
+	}
+}
+
+type FixedStringType struct {
+	StringType
 	Length *ConstExpr
 }
 
-func NewStringType(name string, args ...interface{}) *StringType {
-	if len(args) > 1 {
-		panic(errors.Errorf("too many arguments for NewStringType: %v, %v", name, args))
-	}
-	var length *ConstExpr
-	if len(args) == 1 {
-		switch v := args[0].(type) {
-		case ConstExpr:
-			length = &v
-		case *ConstExpr:
-			length = v
-		}
-	}
-	return &StringType{
-		Name:   name,
-		Length: length,
-	}
+func NewFixedStringType(name interface{}, length *ConstExpr) *FixedStringType {
+	return &FixedStringType{StringType: NewStringType(name), Length: length}
 }
 
-func (*StringType) isType() {}
-func (m *StringType) Children() Nodes {
-	r := Nodes{}
-	if m.Length != nil {
-		r = append(r, m.Length)
-	}
-	return r
+func (*FixedStringType) isType()            {}
+func (*FixedStringType) IsStringType() bool { return true }
+func (m *FixedStringType) Children() Nodes {
+	return Nodes{m.StringType, m.Length}
 }

--- a/parser/parsertest/function_heading_test.go
+++ b/parser/parsertest/function_heading_test.go
@@ -65,7 +65,7 @@ func TestExportHeading(t *testing.T) {
 				Ident: asttest.NewIdent("NumString"),
 				FormalParameters: ast.FormalParameters{
 					asttest.NewFormalParm("N", asttest.NewOrdIdent("Integer")),
-					asttest.NewFormalParm("S", asttest.NewStringType("STRING"), &ast.FpoVar),
+					asttest.NewFormalParm("S", asttest.NewStringType("string"), &ast.FpoVar),
 				},
 			},
 		},
@@ -179,9 +179,9 @@ func TestExportHeading(t *testing.T) {
 				Type:  ast.FtFunction,
 				Ident: asttest.NewIdent("SomeFunction"),
 				FormalParameters: ast.FormalParameters{
-					asttest.NewFormalParm("S", asttest.NewStringType("STRING")),
+					asttest.NewFormalParm("S", asttest.NewStringType("string")),
 				},
-				ReturnType: asttest.NewStringType("STRING"),
+				ReturnType: asttest.NewStringType("string"),
 			},
 			Directives:      []ast.Directive{ast.DrExternal},
 			ExternalOptions: &ast.ExternalOptions{LibraryName: "'strlib.dll'"},
@@ -259,7 +259,7 @@ func TestExportHeading(t *testing.T) {
 				Type:  ast.FtFunction,
 				Ident: asttest.NewIdent("CompareStr"),
 				FormalParameters: ast.FormalParameters{
-					asttest.NewFormalParm([]string{"S1", "S2"}, asttest.NewStringType("STRING"), &ast.FpoConst),
+					asttest.NewFormalParm([]string{"S1", "S2"}, asttest.NewStringType("string"), &ast.FpoConst),
 				},
 				ReturnType: asttest.NewOrdIdent("Integer"),
 			},
@@ -345,7 +345,7 @@ func TestExportHeading(t *testing.T) {
 				FormalParameters: ast.FormalParameters{
 					asttest.NewFormalParm([]string{"Args"}, asttest.NewArrayParameterType(nil), &ast.FpoConst),
 				},
-				ReturnType: asttest.NewStringType("STRING"),
+				ReturnType: asttest.NewStringType("string"),
 			},
 		},
 	)
@@ -399,7 +399,7 @@ func TestExportHeading(t *testing.T) {
 						asttest.NewParameter([]string{"I"}, asttest.NewOrdIdent("Integer"), asttest.NewNumber("0")),
 					),
 					asttest.NewFormalParm(
-						asttest.NewParameter([]string{"S"}, asttest.NewStringType("STRING"), asttest.NewString("''")),
+						asttest.NewParameter([]string{"S"}, asttest.NewStringType("string"), asttest.NewString("''")),
 					),
 				},
 			},
@@ -460,7 +460,7 @@ func TestFormalParameters(t *testing.T) {
 	run(
 		"(var S: string; X: Integer)", true,
 		ast.FormalParameters{
-			asttest.NewFormalParm("S", asttest.NewStringType("STRING"), &ast.FpoVar),
+			asttest.NewFormalParm("S", asttest.NewStringType("string"), &ast.FpoVar),
 			asttest.NewFormalParm("X", asttest.NewOrdIdent("Integer")),
 		},
 	)

--- a/parser/parsertest/program_test.go
+++ b/parser/parsertest/program_test.go
@@ -73,7 +73,7 @@ end.
 					}
 					varDecl := &ast.VarDecl{
 						IdentList: asttest.NewIdentList("msg"),
-						Type:      asttest.NewStringType("STRING"),
+						Type:      asttest.NewStringType("string"),
 					}
 					return &ast.Block{
 						DeclSections: ast.DeclSections{

--- a/parser/parsertest/statement_tests/raise_stmt_test.go
+++ b/parser/parsertest/statement_tests/raise_stmt_test.go
@@ -28,7 +28,7 @@ func TestRaiseStmt(t *testing.T) {
 		Parameter: &ast.Parameter{
 			IdentList: asttest.NewIdentList("Path"),
 			Type: &ast.ParameterType{
-				Type: asttest.NewStringType("STRING"),
+				Type: asttest.NewStringType("string"),
 			},
 		},
 	}

--- a/parser/parsertest/type_string_test.go
+++ b/parser/parsertest/type_string_test.go
@@ -14,16 +14,19 @@ func TestStringType(t *testing.T) {
 		})
 	}
 
-	run("String", []rune(`STRING`), &ast.StringType{Name: "STRING"})
-	run("ANSI String", []rune(`ANSISTRING`), &ast.StringType{Name: "ANSISTRING"})
-	run("Wide String", []rune(`WIDESTRING`), &ast.StringType{Name: "WIDESTRING"})
-	run("Short String", []rune(`STRING[100]`), &ast.StringType{Name: "STRING", Length: asttest.NewConstExpr(asttest.NewNumber("100"))})
+	run("String", []rune(`STRING`), asttest.NewStringType(asttest.NewIdent("STRING", asttest.NewIdentLocation(1, 1, 0, 7))))
+	run("ANSI String", []rune(`ANSISTRING`), asttest.NewStringType(asttest.NewIdent("ANSISTRING", asttest.NewIdentLocation(1, 1, 0, 11))))
+	run("Wide String", []rune(`WIDESTRING`), asttest.NewStringType(asttest.NewIdent("WIDESTRING", asttest.NewIdentLocation(1, 1, 0, 11))))
+	run("Short String", []rune(`STRING[100]`), asttest.NewFixedStringType(
+		asttest.NewIdent("STRING", asttest.NewIdentLocation(1, 1, 0, 7)),
+		asttest.NewConstExpr(asttest.NewNumber("100"))),
+	)
 	run(
 		"Short String",
 		[]rune(`STRING[ALen + BLen]`),
-		&ast.StringType{
-			Name: "STRING",
-			Length: asttest.NewConstExpr(
+		asttest.NewFixedStringType(
+			asttest.NewIdent("STRING", asttest.NewIdentLocation(1, 1, 0, 7)),
+			asttest.NewConstExpr(
 				&ast.SimpleExpression{
 					Term: asttest.NewTerm(asttest.NewIdent("ALen", asttest.NewIdentLocation(1, 8, 7, 12))),
 					AddOpTerms: []*ast.AddOpTerm{
@@ -31,6 +34,6 @@ func TestStringType(t *testing.T) {
 					},
 				},
 			),
-		},
+		),
 	)
 }

--- a/parser/parsertest/type_struc_array_test.go
+++ b/parser/parsertest/type_struc_array_test.go
@@ -21,7 +21,7 @@ func TestStrucArray(t *testing.T) {
 					High: asttest.NewConstExpr(asttest.NewNumber("100")),
 				},
 			},
-			BaseType: &ast.OrdIdent{Ident: asttest.NewIdent("Char")},
+			BaseType: ast.NewOrdIdent(asttest.NewIdent("Char")),
 		},
 	).Run().RunVarSection("MyArray")
 
@@ -85,7 +85,7 @@ func TestStrucArray(t *testing.T) {
 		&ast.ArrayType{
 			Packed: true,
 			IndexTypes: []ast.OrdinalType{
-				&ast.OrdIdent{Ident: asttest.NewIdent("Boolean")},
+				ast.NewOrdIdent(asttest.NewIdent("Boolean")),
 				&ast.SubrangeType{
 					Low:  asttest.NewConstExpr(asttest.NewNumber("1")),
 					High: asttest.NewConstExpr(asttest.NewNumber("10")),
@@ -95,7 +95,7 @@ func TestStrucArray(t *testing.T) {
 					Ref:   tshoeSizeDecl.ToDeclarations()[0],
 				},
 			},
-			BaseType: &ast.OrdIdent{Ident: asttest.NewIdent("Integer")},
+			BaseType: ast.NewOrdIdent(asttest.NewIdent("Integer")),
 		},
 		tshoeSizeContext,
 	).Run()
@@ -106,7 +106,7 @@ func TestStrucArray(t *testing.T) {
 		&ast.ArrayType{
 			Packed: true,
 			IndexTypes: []ast.OrdinalType{
-				&ast.OrdIdent{Ident: asttest.NewIdent("Boolean")},
+				ast.NewOrdIdent(asttest.NewIdent("Boolean")),
 			},
 			BaseType: &ast.ArrayType{
 				Packed: true,
@@ -124,7 +124,7 @@ func TestStrucArray(t *testing.T) {
 							Ref:   tshoeSizeDecl.ToDeclarations()[0],
 						},
 					},
-					BaseType: &ast.OrdIdent{Ident: asttest.NewIdent("Integer")},
+					BaseType: ast.NewOrdIdent(asttest.NewIdent("Integer")),
 				},
 			},
 		},

--- a/parser/parsertest/type_struc_array_test.go
+++ b/parser/parsertest/type_struc_array_test.go
@@ -147,7 +147,7 @@ func TestStrucArray(t *testing.T) {
 			IndexTypes: nil,
 			BaseType: &ast.ArrayType{
 				IndexTypes: nil,
-				BaseType:   &ast.StringType{Name: "STRING"},
+				BaseType:   asttest.NewStringType("string"),
 			},
 		},
 	).Run().RunTypeSection("TMessageGrid")

--- a/parser/parsertest/type_struc_array_test.go
+++ b/parser/parsertest/type_struc_array_test.go
@@ -42,7 +42,7 @@ func TestStrucArray(t *testing.T) {
 						High: asttest.NewConstExpr(asttest.NewNumber("50")),
 					},
 				},
-				BaseType: &ast.RealType{Ident: asttest.NewIdent("Real")},
+				BaseType: ast.NewRealType(asttest.NewIdent("Real")),
 			},
 		},
 	).Run().RunTypeSection("TMatrix")
@@ -61,7 +61,7 @@ func TestStrucArray(t *testing.T) {
 					High: asttest.NewConstExpr(asttest.NewNumber("50")),
 				},
 			},
-			BaseType: &ast.RealType{Ident: asttest.NewIdent("Real")},
+			BaseType: ast.NewRealType(asttest.NewIdent("Real")),
 		},
 	).Run().RunTypeSection("TMatrix")
 
@@ -136,7 +136,7 @@ func TestStrucArray(t *testing.T) {
 		[]rune(`array of Real`),
 		&ast.ArrayType{
 			IndexTypes: nil,
-			BaseType:   &ast.RealType{Ident: asttest.NewIdent("Real")},
+			BaseType:   ast.NewRealType(asttest.NewIdent("Real")),
 		},
 	).Run().RunVarSection("MyFlexibleArray")
 

--- a/parser/parsertest/type_struc_file_test.go
+++ b/parser/parsertest/type_struc_file_test.go
@@ -15,11 +15,11 @@ func TestStrucFileType(t *testing.T) {
 				FieldDecls: ast.FieldDecls{
 					{
 						IdentList: asttest.NewIdentList("FirstName", "LastName"),
-						Type:      &ast.StringType{Name: "STRING", Length: asttest.NewConstExpr(asttest.NewNumber("20"))},
+						Type:      asttest.NewFixedStringType("string", asttest.NewConstExpr(asttest.NewNumber("20"))),
 					},
 					{
 						IdentList: asttest.NewIdentList("PhoneNumber"),
-						Type:      &ast.StringType{Name: "STRING", Length: asttest.NewConstExpr(asttest.NewNumber("15"))},
+						Type:      asttest.NewFixedStringType("string", asttest.NewConstExpr(asttest.NewNumber("15"))),
 					},
 					{
 						IdentList: asttest.NewIdentList("Listed"),

--- a/parser/parsertest/type_struc_file_test.go
+++ b/parser/parsertest/type_struc_file_test.go
@@ -23,7 +23,7 @@ func TestStrucFileType(t *testing.T) {
 					},
 					{
 						IdentList: asttest.NewIdentList("Listed"),
-						Type:      &ast.OrdIdent{Ident: asttest.NewIdent("Boolean")},
+						Type:      ast.NewOrdIdent(asttest.NewIdent("Boolean")),
 					},
 				},
 			},

--- a/parser/parsertest/type_struc_rec_test.go
+++ b/parser/parsertest/type_struc_rec_test.go
@@ -67,7 +67,7 @@ end
 				FieldDecls: ast.FieldDecls{
 					{
 						IdentList: asttest.NewIdentList("Name"),
-						Type:      &ast.StringType{Name: "STRING"},
+						Type:      asttest.NewStringType("string"),
 					},
 					{
 						IdentList: asttest.NewIdentList("Age"),
@@ -94,7 +94,7 @@ end
 				FieldDecls: ast.FieldDecls{
 					{
 						IdentList: asttest.NewIdentList("FirstName", "LastName"),
-						Type:      &ast.StringType{Name: "STRING", Length: asttest.NewConstExpr(asttest.NewNumber("40"))},
+						Type:      asttest.NewFixedStringType("string", asttest.NewConstExpr(asttest.NewNumber("40"))),
 					},
 					{
 						IdentList: asttest.NewIdentList("BirthDate"),
@@ -151,7 +151,7 @@ end
 				FieldDecls: ast.FieldDecls{
 					{
 						IdentList: asttest.NewIdentList("FirstName", "LastName"),
-						Type:      &ast.StringType{Name: "STRING", Length: asttest.NewConstExpr(asttest.NewNumber("40"))},
+						Type:      asttest.NewFixedStringType("string", asttest.NewConstExpr(asttest.NewNumber("40"))),
 					},
 					{
 						IdentList: asttest.NewIdentList("BirthDate"),
@@ -168,7 +168,7 @@ end
 								FieldDecls: ast.FieldDecls{
 									{
 										IdentList: asttest.NewIdentList("Birthplace"),
-										Type:      &ast.StringType{Name: "STRING", Length: asttest.NewConstExpr(asttest.NewNumber("40"))},
+										Type:      asttest.NewFixedStringType("string", asttest.NewConstExpr(asttest.NewNumber("40"))),
 									},
 								},
 							},
@@ -179,11 +179,11 @@ end
 								FieldDecls: ast.FieldDecls{
 									{
 										IdentList: asttest.NewIdentList("Country"),
-										Type:      &ast.StringType{Name: "STRING", Length: asttest.NewConstExpr(asttest.NewNumber("20"))},
+										Type:      asttest.NewFixedStringType("string", asttest.NewConstExpr(asttest.NewNumber("20"))),
 									},
 									{
 										IdentList: asttest.NewIdentList("EntryPort"),
-										Type:      &ast.StringType{Name: "STRING", Length: asttest.NewConstExpr(asttest.NewNumber("20"))},
+										Type:      asttest.NewFixedStringType("string", asttest.NewConstExpr(asttest.NewNumber("20"))),
 									},
 									{
 										IdentList: asttest.NewIdentList("EntryDate", "ExitDate"),

--- a/parser/parsertest/type_struc_rec_test.go
+++ b/parser/parsertest/type_struc_rec_test.go
@@ -23,7 +23,7 @@ end
 				FieldDecls: ast.FieldDecls{
 					{
 						IdentList: asttest.NewIdentList("Year"),
-						Type:      &ast.OrdIdent{Ident: asttest.NewIdent("Integer")},
+						Type:      ast.NewOrdIdent(asttest.NewIdent("Integer")),
 					},
 					{
 						IdentList: asttest.NewIdentList("Month"),
@@ -71,7 +71,7 @@ end
 					},
 					{
 						IdentList: asttest.NewIdentList("Age"),
-						Type:      &ast.OrdIdent{Ident: asttest.NewIdent("Integer")},
+						Type:      ast.NewOrdIdent(asttest.NewIdent("Integer")),
 					},
 				},
 			},
@@ -103,7 +103,7 @@ end
 				},
 				VariantSection: &ast.VariantSection{
 					Ident:  asttest.NewIdent("Salaried"),
-					TypeId: &ast.OrdIdent{Ident: asttest.NewIdent("Boolean")},
+					TypeId: ast.NewOrdIdent(asttest.NewIdent("Boolean")),
 					RecVariants: ast.RecVariants{
 						{
 							ConstExprs: ast.ConstExprs{asttest.NewConstExpr(&ast.ValueFactor{Value: "True"})},
@@ -160,7 +160,7 @@ end
 				},
 				VariantSection: &ast.VariantSection{
 					Ident:  asttest.NewIdent("Citizen"),
-					TypeId: &ast.OrdIdent{Ident: asttest.NewIdent("Boolean")},
+					TypeId: ast.NewOrdIdent(asttest.NewIdent("Boolean")),
 					RecVariants: ast.RecVariants{
 						{
 							ConstExprs: ast.ConstExprs{asttest.NewConstExpr(&ast.ValueFactor{Value: "True"})},

--- a/parser/parsertest/type_struc_rec_test.go
+++ b/parser/parsertest/type_struc_rec_test.go
@@ -111,7 +111,7 @@ end
 								FieldDecls: ast.FieldDecls{
 									{
 										IdentList: asttest.NewIdentList("AnnualSalary"),
-										Type:      &ast.RealType{Ident: asttest.NewIdent("Currency")},
+										Type:      ast.NewRealType(asttest.NewIdent("Currency")),
 									},
 								},
 							},
@@ -122,7 +122,7 @@ end
 								FieldDecls: ast.FieldDecls{
 									{
 										IdentList: asttest.NewIdentList("HourlyWage"),
-										Type:      &ast.RealType{Ident: asttest.NewIdent("Currency")},
+										Type:      ast.NewRealType(asttest.NewIdent("Currency")),
 									},
 								},
 							},
@@ -241,7 +241,7 @@ type
 										FieldDecls: ast.FieldDecls{
 											{
 												IdentList: asttest.NewIdentList("Height", "Width"),
-												Type:      &ast.RealType{Ident: asttest.NewIdent("Real")},
+												Type:      ast.NewRealType(asttest.NewIdent("Real")),
 											},
 										},
 									},
@@ -254,7 +254,7 @@ type
 										FieldDecls: ast.FieldDecls{
 											{
 												IdentList: asttest.NewIdentList("Side1", "Side2", "Angle"),
-												Type:      &ast.RealType{Ident: asttest.NewIdent("Real")},
+												Type:      ast.NewRealType(asttest.NewIdent("Real")),
 											},
 										},
 									},
@@ -267,7 +267,7 @@ type
 										FieldDecls: ast.FieldDecls{
 											{
 												IdentList: asttest.NewIdentList("Radius"),
-												Type:      &ast.RealType{Ident: asttest.NewIdent("Real")},
+												Type:      ast.NewRealType(asttest.NewIdent("Real")),
 											},
 										},
 									},

--- a/parser/parsertest/type_struc_set_test.go
+++ b/parser/parsertest/type_struc_set_test.go
@@ -63,7 +63,7 @@ func TestStrucSet(t *testing.T) {
 		"Set of Byte",
 		[]rune(`set of Byte`),
 		&ast.SetType{
-			OrdinalType: &ast.OrdIdent{Ident: asttest.NewIdent("Byte")},
+			OrdinalType: ast.NewOrdIdent(asttest.NewIdent("Byte")),
 		},
 	).Run()
 
@@ -84,7 +84,7 @@ func TestStrucSet(t *testing.T) {
 		"Set of Char",
 		[]rune(`set of Char`),
 		&ast.SetType{
-			OrdinalType: &ast.OrdIdent{Ident: asttest.NewIdent("Char")},
+			OrdinalType: ast.NewOrdIdent(asttest.NewIdent("Char")),
 		},
 	).Run()
 }

--- a/parser/parsertest/type_test.go
+++ b/parser/parsertest/type_test.go
@@ -73,8 +73,8 @@ func TestUnitWithTypeSection(t *testing.T) {
 						return ast.TypeSection{
 							{Ident: asttest.NewIdent("TMyInteger1"), Type: ast.NewOrdIdent(asttest.NewIdent("INTEGER"))},
 							{Ident: asttest.NewIdent("TMyReal1"), Type: ast.NewRealType(asttest.NewIdent("REAL"))},
-							{Ident: asttest.NewIdent("TMyString1"), Type: &ast.StringType{Name: "STRING"}},
-							{Ident: asttest.NewIdent("TMyString2"), Type: &ast.StringType{Name: "ANSISTRING"}},
+							{Ident: asttest.NewIdent("TMyString1"), Type: asttest.NewStringType("STRING")},
+							{Ident: asttest.NewIdent("TMyString2"), Type: asttest.NewStringType("ANSISTRING")},
 							{Ident: asttest.NewIdent("TMyEnumerated1"), Type: ast.EnumeratedType{tsClick, tsClack, tsClock}},
 							{Ident: asttest.NewIdent("TMySubrange1"), Type: &ast.SubrangeType{
 								Low:  asttest.NewConstExpr(asttest.NewQualId("tsClick", tsClick.ToDeclarations()[0])),
@@ -129,9 +129,9 @@ func TestTypeSection(t *testing.T) {
 			TMyString1 = STRING;
 			TMyReal1 = REAL;`),
 		ast.TypeSection{
-			{Ident: asttest.NewIdent("TMyInteger1"), Type: ast.NewOrdIdent(asttest.NewIdent("INTEGER"))},
-			{Ident: asttest.NewIdent("TMyString1"), Type: &ast.StringType{Name: "STRING"}},
-			{Ident: asttest.NewIdent("TMyReal1"), Type: ast.NewRealType(asttest.NewIdent("REAL"))},
+			{Ident: asttest.NewIdent("TMyInteger1"), Type: asttest.NewOrdIdent(asttest.NewIdent("INTEGER"))},
+			{Ident: asttest.NewIdent("TMyString1"), Type: asttest.NewStringType("STRING")},
+			{Ident: asttest.NewIdent("TMyReal1"), Type: asttest.NewRealType(asttest.NewIdent("REAL"))},
 		},
 	)
 }

--- a/parser/parsertest/type_test.go
+++ b/parser/parsertest/type_test.go
@@ -72,7 +72,7 @@ func TestUnitWithTypeSection(t *testing.T) {
 						tsClock := &ast.EnumeratedTypeElement{Ident: asttest.NewIdent("tsClock")}
 						return ast.TypeSection{
 							{Ident: asttest.NewIdent("TMyInteger1"), Type: &ast.OrdIdent{Ident: asttest.NewIdent("INTEGER")}},
-							{Ident: asttest.NewIdent("TMyReal1"), Type: &ast.RealType{Ident: asttest.NewIdent("REAL")}},
+							{Ident: asttest.NewIdent("TMyReal1"), Type: ast.NewRealType(asttest.NewIdent("REAL"))},
 							{Ident: asttest.NewIdent("TMyString1"), Type: &ast.StringType{Name: "STRING"}},
 							{Ident: asttest.NewIdent("TMyString2"), Type: &ast.StringType{Name: "ANSISTRING"}},
 							{Ident: asttest.NewIdent("TMyEnumerated1"), Type: ast.EnumeratedType{tsClick, tsClack, tsClock}},
@@ -131,7 +131,7 @@ func TestTypeSection(t *testing.T) {
 		ast.TypeSection{
 			{Ident: asttest.NewIdent("TMyInteger1"), Type: &ast.OrdIdent{Ident: asttest.NewIdent("INTEGER")}},
 			{Ident: asttest.NewIdent("TMyString1"), Type: &ast.StringType{Name: "STRING"}},
-			{Ident: asttest.NewIdent("TMyReal1"), Type: &ast.RealType{Ident: asttest.NewIdent("REAL")}},
+			{Ident: asttest.NewIdent("TMyReal1"), Type: ast.NewRealType(asttest.NewIdent("REAL"))},
 		},
 	)
 }
@@ -252,11 +252,11 @@ func TestNamedType(t *testing.T) {
 	run([]rune(`WIDECHAR`), &ast.OrdIdent{Ident: asttest.NewIdent("WIDECHAR")})
 	run([]rune(`BOOLEAN`), &ast.OrdIdent{Ident: asttest.NewIdent("BOOLEAN")})
 
-	run([]rune(`REAL48`), &ast.RealType{Ident: asttest.NewIdent("REAL48")})
-	run([]rune(`REAL`), &ast.RealType{Ident: asttest.NewIdent("REAL")})
-	run([]rune(`SINGLE`), &ast.RealType{Ident: asttest.NewIdent("SINGLE")})
-	run([]rune(`DOUBLE`), &ast.RealType{Ident: asttest.NewIdent("DOUBLE")})
-	run([]rune(`EXTENDED`), &ast.RealType{Ident: asttest.NewIdent("EXTENDED")})
-	run([]rune(`CURRENCY`), &ast.RealType{Ident: asttest.NewIdent("CURRENCY")})
-	run([]rune(`COMP`), &ast.RealType{Ident: asttest.NewIdent("COMP")})
+	run([]rune(`REAL48`), ast.NewRealType(asttest.NewIdent("REAL48")))
+	run([]rune(`REAL`), ast.NewRealType(asttest.NewIdent("REAL")))
+	run([]rune(`SINGLE`), ast.NewRealType(asttest.NewIdent("SINGLE")))
+	run([]rune(`DOUBLE`), ast.NewRealType(asttest.NewIdent("DOUBLE")))
+	run([]rune(`EXTENDED`), ast.NewRealType(asttest.NewIdent("EXTENDED")))
+	run([]rune(`CURRENCY`), ast.NewRealType(asttest.NewIdent("CURRENCY")))
+	run([]rune(`COMP`), ast.NewRealType(asttest.NewIdent("COMP")))
 }

--- a/parser/parsertest/type_test.go
+++ b/parser/parsertest/type_test.go
@@ -71,7 +71,7 @@ func TestUnitWithTypeSection(t *testing.T) {
 						tsClack := &ast.EnumeratedTypeElement{Ident: asttest.NewIdent("tsClack")}
 						tsClock := &ast.EnumeratedTypeElement{Ident: asttest.NewIdent("tsClock")}
 						return ast.TypeSection{
-							{Ident: asttest.NewIdent("TMyInteger1"), Type: &ast.OrdIdent{Ident: asttest.NewIdent("INTEGER")}},
+							{Ident: asttest.NewIdent("TMyInteger1"), Type: ast.NewOrdIdent(asttest.NewIdent("INTEGER"))},
 							{Ident: asttest.NewIdent("TMyReal1"), Type: ast.NewRealType(asttest.NewIdent("REAL"))},
 							{Ident: asttest.NewIdent("TMyString1"), Type: &ast.StringType{Name: "STRING"}},
 							{Ident: asttest.NewIdent("TMyString2"), Type: &ast.StringType{Name: "ANSISTRING"}},
@@ -129,7 +129,7 @@ func TestTypeSection(t *testing.T) {
 			TMyString1 = STRING;
 			TMyReal1 = REAL;`),
 		ast.TypeSection{
-			{Ident: asttest.NewIdent("TMyInteger1"), Type: &ast.OrdIdent{Ident: asttest.NewIdent("INTEGER")}},
+			{Ident: asttest.NewIdent("TMyInteger1"), Type: ast.NewOrdIdent(asttest.NewIdent("INTEGER"))},
 			{Ident: asttest.NewIdent("TMyString1"), Type: &ast.StringType{Name: "STRING"}},
 			{Ident: asttest.NewIdent("TMyReal1"), Type: ast.NewRealType(asttest.NewIdent("REAL"))},
 		},
@@ -238,19 +238,19 @@ func TestNamedType(t *testing.T) {
 		RunTypeTest(t, string(text), text, expected)
 	}
 
-	run([]rune(`INTEGER`), &ast.OrdIdent{Ident: asttest.NewIdent("INTEGER")})
-	run([]rune(`CARDINAL`), &ast.OrdIdent{Ident: asttest.NewIdent("CARDINAL")})
-	run([]rune(`SHORTINT`), &ast.OrdIdent{Ident: asttest.NewIdent("SHORTINT")})
-	run([]rune(`SMALLINT`), &ast.OrdIdent{Ident: asttest.NewIdent("SMALLINT")})
-	run([]rune(`LONGINT`), &ast.OrdIdent{Ident: asttest.NewIdent("LONGINT")})
-	run([]rune(`INT64`), &ast.OrdIdent{Ident: asttest.NewIdent("INT64")})
-	run([]rune(`BYTE`), &ast.OrdIdent{Ident: asttest.NewIdent("BYTE")})
-	run([]rune(`WORD`), &ast.OrdIdent{Ident: asttest.NewIdent("WORD")})
-	run([]rune(`LONGWORD`), &ast.OrdIdent{Ident: asttest.NewIdent("LONGWORD")})
-	run([]rune(`CHAR`), &ast.OrdIdent{Ident: asttest.NewIdent("CHAR")})
-	run([]rune(`ANSICHAR`), &ast.OrdIdent{Ident: asttest.NewIdent("ANSICHAR")})
-	run([]rune(`WIDECHAR`), &ast.OrdIdent{Ident: asttest.NewIdent("WIDECHAR")})
-	run([]rune(`BOOLEAN`), &ast.OrdIdent{Ident: asttest.NewIdent("BOOLEAN")})
+	run([]rune(`INTEGER`), ast.NewOrdIdent(asttest.NewIdent("INTEGER")))
+	run([]rune(`CARDINAL`), ast.NewOrdIdent(asttest.NewIdent("CARDINAL")))
+	run([]rune(`SHORTINT`), ast.NewOrdIdent(asttest.NewIdent("SHORTINT")))
+	run([]rune(`SMALLINT`), ast.NewOrdIdent(asttest.NewIdent("SMALLINT")))
+	run([]rune(`LONGINT`), ast.NewOrdIdent(asttest.NewIdent("LONGINT")))
+	run([]rune(`INT64`), ast.NewOrdIdent(asttest.NewIdent("INT64")))
+	run([]rune(`BYTE`), ast.NewOrdIdent(asttest.NewIdent("BYTE")))
+	run([]rune(`WORD`), ast.NewOrdIdent(asttest.NewIdent("WORD")))
+	run([]rune(`LONGWORD`), ast.NewOrdIdent(asttest.NewIdent("LONGWORD")))
+	run([]rune(`CHAR`), ast.NewOrdIdent(asttest.NewIdent("CHAR")))
+	run([]rune(`ANSICHAR`), ast.NewOrdIdent(asttest.NewIdent("ANSICHAR")))
+	run([]rune(`WIDECHAR`), ast.NewOrdIdent(asttest.NewIdent("WIDECHAR")))
+	run([]rune(`BOOLEAN`), ast.NewOrdIdent(asttest.NewIdent("BOOLEAN")))
 
 	run([]rune(`REAL48`), ast.NewRealType(asttest.NewIdent("REAL48")))
 	run([]rune(`REAL`), ast.NewRealType(asttest.NewIdent("REAL")))

--- a/parser/parsertest/unit_test/same_ident_test/main_test.go
+++ b/parser/parsertest/unit_test/same_ident_test/main_test.go
@@ -37,7 +37,7 @@ func TestSameIdent(t *testing.T) {
 	newStringVarDecl := func(name, value string) *ast.VarDecl {
 		return &ast.VarDecl{
 			IdentList: asttest.NewIdentList(asttest.NewIdent(name)),
-			Type:      asttest.NewStringType("STRING"),
+			Type:      asttest.NewStringType("string"),
 			ConstExpr: asttest.NewConstExpr(asttest.NewString("'" + value + "'")),
 		}
 	}

--- a/parser/parsertest/var_test.go
+++ b/parser/parsertest/var_test.go
@@ -24,7 +24,7 @@ func TestUnitWithVarSection(t *testing.T) {
 			InterfaceSection: &ast.InterfaceSection{
 				InterfaceDecls: ast.InterfaceDecls{
 					ast.VarSection{
-						{IdentList: asttest.NewIdentList("I"), Type: &ast.OrdIdent{Ident: asttest.NewIdent("Integer")}},
+						{IdentList: asttest.NewIdentList("I"), Type: ast.NewOrdIdent(asttest.NewIdent("Integer"))},
 						{IdentList: asttest.NewIdentList("X", "Y"), Type: ast.NewRealType(asttest.NewIdent("Real"))},
 					},
 				},
@@ -52,12 +52,12 @@ func TestUnitWithVarSection(t *testing.T) {
 				InterfaceDecls: []ast.InterfaceDecl{
 					ast.VarSection{
 						{IdentList: asttest.NewIdentList("X", "Y", "Z"), Type: ast.NewRealType(asttest.NewIdent("Double"))},
-						{IdentList: asttest.NewIdentList("I", "J", "K"), Type: &ast.OrdIdent{Ident: asttest.NewIdent("Integer")}},
+						{IdentList: asttest.NewIdentList("I", "J", "K"), Type: ast.NewOrdIdent(asttest.NewIdent("Integer"))},
 					},
 					ast.VarSection{
 						{IdentList: asttest.NewIdentList("Digit"), Type: &ast.SubrangeType{Low: asttest.NewConstExpr(asttest.NewNumber("0")), High: asttest.NewConstExpr(asttest.NewNumber("9"))}},
-						{IdentList: asttest.NewIdentList("Okay"), Type: &ast.OrdIdent{Ident: asttest.NewIdent("Boolean")}},
-						{IdentList: asttest.NewIdentList("A"), Type: &ast.OrdIdent{Ident: asttest.NewIdent("Integer")}, ConstExpr: asttest.NewExpression(asttest.NewNumber("7"))},
+						{IdentList: asttest.NewIdentList("Okay"), Type: ast.NewOrdIdent(asttest.NewIdent("Boolean"))},
+						{IdentList: asttest.NewIdentList("A"), Type: ast.NewOrdIdent(asttest.NewIdent("Integer")), ConstExpr: asttest.NewExpression(asttest.NewNumber("7"))},
 					},
 				},
 			},
@@ -78,7 +78,7 @@ func TestUnitWithVarSection(t *testing.T) {
 			InterfaceSection: &ast.InterfaceSection{
 				InterfaceDecls: []ast.InterfaceDecl{
 					ast.ThreadVarSection{
-						{IdentList: asttest.NewIdentList("X"), Type: &ast.OrdIdent{Ident: asttest.NewIdent("Integer")}},
+						{IdentList: asttest.NewIdentList("X"), Type: ast.NewOrdIdent(asttest.NewIdent("Integer"))},
 					},
 				},
 			},
@@ -107,7 +107,7 @@ func TestVarSectionl(t *testing.T) {
 			},
 			&ast.VarDecl{
 				IdentList: asttest.NewIdentList(asttest.NewIdent("StrLen", asttest.NewIdentLocation(3, 3, 25, 9))),
-				Type:      &ast.OrdIdent{Ident: asttest.NewIdent("Byte", asttest.NewIdentLocation(3, 11, 33, 15))},
+				Type:      ast.NewOrdIdent(asttest.NewIdent("Byte", asttest.NewIdentLocation(3, 11, 33, 15))),
 				Absolute:  asttest.NewVarDeclAbsoluteIdent(asttest.NewIdent("Str", asttest.NewIdentLocation(3, 25, 47, 28))),
 			},
 		},
@@ -118,7 +118,7 @@ func TestVarSectionl(t *testing.T) {
 		ast.VarSection{
 			{
 				IdentList: asttest.NewIdentList(asttest.NewIdent("A", asttest.NewIdentLocation(1, 5, 4, 6))),
-				Type:      &ast.OrdIdent{Ident: asttest.NewIdent("Integer", asttest.NewIdentLocation(1, 8, 7, 15))},
+				Type:      ast.NewOrdIdent(asttest.NewIdent("Integer", asttest.NewIdentLocation(1, 8, 7, 15))),
 				ConstExpr: asttest.NewExpression(asttest.NewNumber("7")),
 			},
 		},
@@ -137,14 +137,14 @@ func TestVarSectionl(t *testing.T) {
 				Type:      &ast.SubrangeType{Low: asttest.NewConstExpr(asttest.NewNumber("0")), High: asttest.NewConstExpr(asttest.NewNumber("9"))}},
 			{
 				IdentList: asttest.NewIdentList(asttest.NewIdent("Okay", asttest.NewIdentLocation(3, 4, 26, 8))),
-				Type:      &ast.OrdIdent{Ident: asttest.NewIdent("Boolean", asttest.NewIdentLocation(3, 10, 32, 17))},
+				Type:      ast.NewOrdIdent(asttest.NewIdent("Boolean", asttest.NewIdentLocation(3, 10, 32, 17))),
 			},
 		},
 	)
 }
 
 func TestVarReferringType(t *testing.T) {
-	typeDecl := &ast.TypeDecl{Ident: asttest.NewIdent("TMyInteger1"), Type: &ast.OrdIdent{Ident: asttest.NewIdent("INTEGER")}}
+	typeDecl := &ast.TypeDecl{Ident: asttest.NewIdent("TMyInteger1"), Type: ast.NewOrdIdent(asttest.NewIdent("INTEGER"))}
 
 	RunUnitTest(t,
 		"reference from var to type in unit",

--- a/parser/parsertest/var_test.go
+++ b/parser/parsertest/var_test.go
@@ -25,7 +25,7 @@ func TestUnitWithVarSection(t *testing.T) {
 				InterfaceDecls: ast.InterfaceDecls{
 					ast.VarSection{
 						{IdentList: asttest.NewIdentList("I"), Type: &ast.OrdIdent{Ident: asttest.NewIdent("Integer")}},
-						{IdentList: asttest.NewIdentList("X", "Y"), Type: &ast.RealType{Ident: asttest.NewIdent("Real")}},
+						{IdentList: asttest.NewIdentList("X", "Y"), Type: ast.NewRealType(asttest.NewIdent("Real"))},
 					},
 				},
 			},
@@ -51,7 +51,7 @@ func TestUnitWithVarSection(t *testing.T) {
 			InterfaceSection: &ast.InterfaceSection{
 				InterfaceDecls: []ast.InterfaceDecl{
 					ast.VarSection{
-						{IdentList: asttest.NewIdentList("X", "Y", "Z"), Type: &ast.RealType{Ident: asttest.NewIdent("Double")}},
+						{IdentList: asttest.NewIdentList("X", "Y", "Z"), Type: ast.NewRealType(asttest.NewIdent("Double"))},
 						{IdentList: asttest.NewIdentList("I", "J", "K"), Type: &ast.OrdIdent{Ident: asttest.NewIdent("Integer")}},
 					},
 					ast.VarSection{

--- a/parser/parsertest/var_test.go
+++ b/parser/parsertest/var_test.go
@@ -103,7 +103,7 @@ func TestVarSectionl(t *testing.T) {
 		ast.VarSection{
 			&ast.VarDecl{
 				IdentList: asttest.NewIdentList(asttest.NewIdent("Str", asttest.NewIdentLocation(2, 3, 6, 6))),
-				Type:      asttest.NewStringType("STRING", asttest.NewConstExpr(asttest.NewNumber("32"))),
+				Type:      asttest.NewFixedStringType(asttest.NewIdent("string", asttest.NewIdentLocation(2, 8, 11, 14)), asttest.NewConstExpr(asttest.NewNumber("32"))),
 			},
 			&ast.VarDecl{
 				IdentList: asttest.NewIdentList(asttest.NewIdent("StrLen", asttest.NewIdentLocation(3, 3, 25, 9))),

--- a/parser/type_simple.go
+++ b/parser/type_simple.go
@@ -19,13 +19,12 @@ func (p *Parser) ParseRealType(required bool) (ast.RealType, error) {
 	}
 }
 
-var ordIdent = token.PredicatorBy("OrdIdent", ast.IsOrdIdentName)
-
-func (p *Parser) ParseOrdIdent(required bool) (*ast.OrdIdent, error) {
+func (p *Parser) ParseOrdIdent(required bool) (ast.OrdIdent, error) {
 	t := p.CurrentToken()
-	if t.Is(ordIdent) {
+	decl := ast.EmbeddedTypeDecl(ast.EtkOrdIdent, t.Value())
+	if decl != nil {
 		p.NextToken()
-		return &ast.OrdIdent{Ident: p.NewIdent(t)}, nil
+		return ast.NewTypeId(p.NewIdent(t), decl), nil
 	} else if required {
 		return nil, p.TokenErrorf("Unsupported token %s for OrdIdent", t)
 	} else {

--- a/parser/type_simple.go
+++ b/parser/type_simple.go
@@ -8,7 +8,7 @@ import (
 
 func (p *Parser) ParseRealType(required bool) (ast.RealType, error) {
 	t := p.CurrentToken()
-	decl := ast.EmbeddedRealTypeDecl(t.Value())
+	decl := ast.EmbeddedTypeDecl(ast.EtkReal, t.Value())
 	if decl != nil {
 		p.NextToken()
 		return ast.NewTypeId(p.NewIdent(t), decl), nil

--- a/parser/type_simple.go
+++ b/parser/type_simple.go
@@ -6,13 +6,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-var realType = token.PredicatorBy("RealType", ast.IsRealTypeName)
-
-func (p *Parser) ParseRealType(required bool) (*ast.RealType, error) {
+func (p *Parser) ParseRealType(required bool) (ast.RealType, error) {
 	t := p.CurrentToken()
-	if t.Is(realType) {
+	decl := ast.EmbeddedRealTypeDecl(t.Value())
+	if decl != nil {
 		p.NextToken()
-		return &ast.RealType{Ident: p.NewIdent(t)}, nil
+		return ast.NewTypeId(p.NewIdent(t), decl), nil
 	} else if required {
 		return nil, p.TokenErrorf("Unsupported token %s for RealType", t)
 	} else {

--- a/parser/type_string.go
+++ b/parser/type_string.go
@@ -5,13 +5,12 @@ import (
 	"github.com/akm/tparser/token"
 )
 
-var stringType = token.PredicatorBy("StringType", ast.IsStringTypeName)
-
-func (p *Parser) ParseStringType(required bool) (*ast.StringType, error) {
+func (p *Parser) ParseStringType(required bool) (ast.StringType, error) {
 	t := p.CurrentToken()
-	if t.Is(stringType) {
+	decl := ast.EmbeddedTypeDecl(ast.EtkStringType, t.Value())
+	if decl != nil {
 		p.NextToken()
-		return &ast.StringType{Name: t.Value()}, nil
+		return ast.NewTypeId(p.NewIdent(t), decl), nil
 	} else if required {
 		return nil, p.TokenErrorf("Unsupported token %s for StringType", t)
 	} else {
@@ -20,9 +19,10 @@ func (p *Parser) ParseStringType(required bool) (*ast.StringType, error) {
 }
 
 // This method parses just STRING not ANSISTRING nor WIDESTRING
-func (p *Parser) ParseStringOfStringType() (*ast.StringType, error) {
+func (p *Parser) ParseStringOfStringType() (ast.StringType, error) {
 	t1 := p.CurrentToken()
-	if !t1.Is(token.Value("STRING")) {
+	decl := ast.EmbeddedTypeDecl(ast.EtkStringType, t1.Value())
+	if decl == nil {
 		return nil, nil
 	}
 	t2 := p.NextToken()
@@ -36,8 +36,8 @@ func (p *Parser) ParseStringOfStringType() (*ast.StringType, error) {
 			return nil, err
 		}
 		p.NextToken()
-		return &ast.StringType{Name: "STRING", Length: expr}, nil
+		return ast.NewFixedStringType(p.NewIdent(t1), expr), nil
 	} else {
-		return &ast.StringType{Name: t1.Value()}, nil
+		return ast.NewTypeId(p.NewIdent(t1), decl), nil
 	}
 }


### PR DESCRIPTION
- Define `ast.TypeEmbedded` for embedded types
- Modify the following struct types to interface 
    - RealType
    - OrdIdent
    - StringType
        - `FixedStringType` is defined for string with length
- `ast.TypeId` implements above interfaces and refers `ast.TypeEmbedded`
