### PR TITLE
Pointer type support

### DIFF
--- a/ast/asttest/type_simple.go
+++ b/ast/asttest/type_simple.go
@@ -21,3 +21,7 @@ func NewOrdIdent(name interface{}) ast.OrdIdent {
 		return ast.NewOrdIdent(name)
 	}
 }
+
+func NewOrdIdentWithIdent(v *ast.Ident) *ast.TypeId {
+	return ast.NewOrdIdentWithIdent(v)
+}

--- a/ast/type_embedded.go
+++ b/ast/type_embedded.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/akm/tparser/ast/astcore"
+	"github.com/pkg/errors"
 )
 
 type EmbeddedTypeKind int
@@ -73,11 +74,14 @@ var embeddedTypeDeclMaps = func() map[EmbeddedTypeKind]map[string]*astcore.Decl 
 	return r
 }()
 
+var embeddedTypeDeclMap = map[string]*astcore.Decl{}
+
 func newEmbeddedTypeDecl(kind EmbeddedTypeKind, name string) *TypeDecl {
 	typ := newTypeEmbedded(kind, name)
 	typeDecl := &TypeDecl{Ident: typ.Ident, Type: typ}
 	key := strings.ToUpper(typ.Ident.Name)
 	decl := typeDecl.ToDeclarations()[0]
+	embeddedTypeDeclMap[key] = decl
 	embeddedTypeDeclMaps[kind][key] = decl
 	return typeDecl
 }
@@ -118,3 +122,16 @@ var (
 	EmbeddedPAnsiChar = newEmbeddedTypeDecl(EtkPointerType, "PAnsiChar")
 	EmbeddedPWideChar = newEmbeddedTypeDecl(EtkPointerType, "PWideChar")
 )
+
+type embeddedTypeDeclMapSingleton struct {
+}
+
+func (m *embeddedTypeDeclMapSingleton) Get(name string) *astcore.Decl {
+	return embeddedTypeDeclMap[strings.ToUpper(name)]
+}
+
+func (m *embeddedTypeDeclMapSingleton) Set(astcore.DeclNode) error {
+	return errors.Errorf("Can't set anything to embedded type decl map")
+}
+
+var EmbeddedTypeDeclMap = &embeddedTypeDeclMapSingleton{}

--- a/ast/type_embedded.go
+++ b/ast/type_embedded.go
@@ -12,6 +12,7 @@ const (
 	EtkReal EmbeddedTypeKind = iota + 1
 	EtkOrdIdent
 	EtkStringType
+	EtkPointerType
 )
 
 type TypeEmbedded struct {
@@ -105,5 +106,8 @@ var (
 	EmbeddedAnsiString = newEmbeddedTypeDecl(EtkStringType, "AnsiString")
 	EmbeddedWideString = newEmbeddedTypeDecl(EtkStringType, "WideString")
 
-	// TODO Define Embedded Pointer Types PChar, PInteger, PByteArray, etc.
+	EmbeddedPointer   = newEmbeddedTypeDecl(EtkStringType, "Pointer")
+	EmbeddedPChar     = newEmbeddedTypeDecl(EtkStringType, "PChar")
+	EmbeddedPAnsiChar = newEmbeddedTypeDecl(EtkStringType, "PAnsiChar")
+	EmbeddedPWideChar = newEmbeddedTypeDecl(EtkStringType, "PWideChar")
 )

--- a/ast/type_embedded.go
+++ b/ast/type_embedded.go
@@ -15,6 +15,13 @@ const (
 	EtkPointerType
 )
 
+var embeddedTypeKindAll = []EmbeddedTypeKind{
+	EtkReal,
+	EtkOrdIdent,
+	EtkStringType,
+	EtkPointerType,
+}
+
 type TypeEmbedded struct {
 	Kind  EmbeddedTypeKind
 	Ident *Ident
@@ -60,7 +67,7 @@ func (m *TypeEmbedded) IsStringType() bool {
 
 var embeddedTypeDeclMaps = func() map[EmbeddedTypeKind]map[string]*astcore.Decl {
 	r := make(map[EmbeddedTypeKind]map[string]*astcore.Decl)
-	for _, kind := range []EmbeddedTypeKind{EtkReal, EtkOrdIdent, EtkStringType} {
+	for _, kind := range embeddedTypeKindAll {
 		r[kind] = make(map[string]*astcore.Decl)
 	}
 	return r
@@ -106,8 +113,8 @@ var (
 	EmbeddedAnsiString = newEmbeddedTypeDecl(EtkStringType, "AnsiString")
 	EmbeddedWideString = newEmbeddedTypeDecl(EtkStringType, "WideString")
 
-	EmbeddedPointer   = newEmbeddedTypeDecl(EtkStringType, "Pointer")
-	EmbeddedPChar     = newEmbeddedTypeDecl(EtkStringType, "PChar")
-	EmbeddedPAnsiChar = newEmbeddedTypeDecl(EtkStringType, "PAnsiChar")
-	EmbeddedPWideChar = newEmbeddedTypeDecl(EtkStringType, "PWideChar")
+	EmbeddedPointer   = newEmbeddedTypeDecl(EtkPointerType, "Pointer")
+	EmbeddedPChar     = newEmbeddedTypeDecl(EtkPointerType, "PChar")
+	EmbeddedPAnsiChar = newEmbeddedTypeDecl(EtkPointerType, "PAnsiChar")
+	EmbeddedPWideChar = newEmbeddedTypeDecl(EtkPointerType, "PWideChar")
 )

--- a/ast/type_id.go
+++ b/ast/type_id.go
@@ -120,3 +120,15 @@ func (m *TypeId) IsStringType() bool {
 	}
 	return ordIdent.IsStringType()
 }
+
+func (m *TypeId) IsPointerType() bool {
+	decl := m.getRefNodeDecl()
+	if decl == nil {
+		return false
+	}
+	ordIdent, ok := decl.Type.(PointerType)
+	if !ok {
+		return false
+	}
+	return ordIdent.IsPointerType()
+}

--- a/ast/type_pointer.go
+++ b/ast/type_pointer.go
@@ -1,0 +1,24 @@
+package ast
+
+// - PointerType
+//   ```
+//   '^' TypeId [PortabilityDirective]
+//   ```
+type PointerType interface {
+	IsPointerType() bool
+	// implements
+	Type
+}
+
+type CustomPointerType struct {
+	TypeId *TypeId
+	// implements
+	PointerType
+}
+
+func NewCustomPointerType(typeId *TypeId) *CustomPointerType {
+	return &CustomPointerType{TypeId: typeId}
+}
+
+func (*CustomPointerType) isType()             {}
+func (*CustomPointerType) IsPointerType() bool { return true }

--- a/ast/type_pointer.go
+++ b/ast/type_pointer.go
@@ -10,6 +10,14 @@ type PointerType interface {
 	Type
 }
 
+func NewEmbeddedPointerType(v *Ident) *TypeId {
+	if decl := EmbeddedTypeDecl(EtkPointerType, v.Name); decl != nil {
+		return NewTypeId(v, decl)
+	} else {
+		return NewTypeId(v)
+	}
+}
+
 type CustomPointerType struct {
 	TypeId *TypeId
 	// implements

--- a/ast/type_pointer.go
+++ b/ast/type_pointer.go
@@ -30,3 +30,6 @@ func NewCustomPointerType(typeId *TypeId) *CustomPointerType {
 
 func (*CustomPointerType) isType()             {}
 func (*CustomPointerType) IsPointerType() bool { return true }
+func (m *CustomPointerType) Children() Nodes {
+	return Nodes{m.TypeId}
+}

--- a/ast/type_simple.go
+++ b/ast/type_simple.go
@@ -122,19 +122,19 @@ func NewOrdIdent(name interface{}) OrdIdent {
 	case OrdIdent:
 		return v
 	case Ident:
-		if decl := EmbeddedTypeDecl(EtkOrdIdent, v.Name); decl != nil {
-			return NewTypeId(&v, decl)
-		} else {
-			return NewTypeId(&v)
-		}
+		return NewOrdIdentWithIdent(&v)
 	case *Ident:
-		if decl := EmbeddedTypeDecl(EtkOrdIdent, v.Name); decl != nil {
-			return NewTypeId(v, decl)
-		} else {
-			return NewTypeId(v)
-		}
+		return NewOrdIdentWithIdent(v)
 	default:
 		panic(errors.Errorf("invalid type %T for NewOrdIndent %+v", name, name))
+	}
+}
+
+func NewOrdIdentWithIdent(v *Ident) *TypeId {
+	if decl := EmbeddedTypeDecl(EtkOrdIdent, v.Name); decl != nil {
+		return NewTypeId(v, decl)
+	} else {
+		return NewTypeId(v)
 	}
 }
 

--- a/parser/parsertest/aliases.go
+++ b/parser/parsertest/aliases.go
@@ -58,3 +58,11 @@ var (
 	NewProgramTestRunner = runners.NewProgramTestRunner
 	RunProgramTest       = runners.RunProgramTest
 )
+
+// block_test_runner.go
+type BlockTestRunner = runners.BlockTestRunner
+
+var (
+	NewBlockTestRunner = runners.NewBlockTestRunner
+	RunBlockTest       = runners.RunBlockTest
+)

--- a/parser/parsertest/expression_test.go
+++ b/parser/parsertest/expression_test.go
@@ -194,7 +194,13 @@ func TestExpression(t *testing.T) {
 		asttest.NewExpression(
 			&ast.DesignatorFactor{
 				Designator: &ast.Designator{
-					QualId: ast.NewQualId(nil, asttest.NewIdentRef("Char", asttest.NewIdentLocation(1, 1, 0, 1, 5, 4))),
+					QualId: ast.NewQualId(nil,
+						asttest.NewIdentRef(
+							"Char",
+							ast.EmbeddedTypeDeclMap.Get("Char"),
+							asttest.NewIdentLocation(1, 1, 0, 1, 5, 4),
+						),
+					),
 				},
 				ExprList: ast.ExprList{
 					asttest.NewExpression(asttest.NewNumber("48")),

--- a/parser/parsertest/expression_test.go
+++ b/parser/parsertest/expression_test.go
@@ -192,19 +192,11 @@ func TestExpression(t *testing.T) {
 		"value typecast", false,
 		[]rune(`Char(48)`),
 		asttest.NewExpression(
-			&ast.DesignatorFactor{
-				Designator: &ast.Designator{
-					QualId: ast.NewQualId(nil,
-						asttest.NewIdentRef(
-							"Char",
-							ast.EmbeddedTypeDeclMap.Get("Char"),
-							asttest.NewIdentLocation(1, 1, 0, 1, 5, 4),
-						),
-					),
-				},
-				ExprList: ast.ExprList{
-					asttest.NewExpression(asttest.NewNumber("48")),
-				},
+			&ast.TypeCast{
+				TypeId: ast.NewOrdIdentWithIdent(asttest.NewIdent("Char", asttest.NewIdentLocation(1, 1, 0, 5))),
+				Expression: asttest.NewExpression(
+					asttest.NewNumber("48"),
+				),
 			},
 		),
 	)

--- a/parser/parsertest/function_heading_test.go
+++ b/parser/parsertest/function_heading_test.go
@@ -150,7 +150,7 @@ func TestExportHeading(t *testing.T) {
 				Type:  ast.FtFunction,
 				Ident: asttest.NewIdent("printf"),
 				FormalParameters: ast.FormalParameters{
-					asttest.NewFormalParm("Format", "PChar"),
+					asttest.NewFormalParm("Format", ast.NewEmbeddedPointerType(asttest.NewIdent("PChar"))),
 				},
 				ReturnType: asttest.NewOrdIdent("Integer"),
 			},
@@ -196,7 +196,7 @@ func TestExportHeading(t *testing.T) {
 				Ident: asttest.NewIdent("MessageBox"),
 				FormalParameters: ast.FormalParameters{
 					asttest.NewFormalParm("HWnd", asttest.NewOrdIdent("Integer")),
-					asttest.NewFormalParm([]string{"Text", "Caption"}, "PChar"),
+					asttest.NewFormalParm([]string{"Text", "Caption"}, ast.NewEmbeddedPointerType(asttest.NewIdent("PChar"))),
 					asttest.NewFormalParm("Flags", asttest.NewOrdIdent("Integer")),
 				},
 				ReturnType: asttest.NewOrdIdent("Integer"),
@@ -476,7 +476,7 @@ func TestFormalParameters(t *testing.T) {
 					asttest.NewIdent("Text", asttest.NewIdentLocation(1, 17, 16, 21)),
 					asttest.NewIdent("Caption", asttest.NewIdentLocation(1, 23, 22, 30)),
 				},
-				asttest.NewIdent("PChar", asttest.NewIdentLocation(1, 32, 31, 37)),
+				ast.NewEmbeddedPointerType(asttest.NewIdent("PChar", asttest.NewIdentLocation(1, 32, 31, 37))),
 			),
 			asttest.NewFormalParm(
 				asttest.NewIdent("PChar", asttest.NewIdentLocation(1, 39, 38, 44)),

--- a/parser/parsertest/runners/block_test_runner.go
+++ b/parser/parsertest/runners/block_test_runner.go
@@ -1,0 +1,53 @@
+package runners
+
+import (
+	"testing"
+
+	"github.com/akm/tparser/ast"
+	"github.com/akm/tparser/ast/astcore"
+	"github.com/akm/tparser/ast/asttest"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func RunBlockTest(t *testing.T, name string, text []rune, expected *ast.Block, args ...interface{}) {
+	NewBlockTestRunner(t, name, text, expected, args...).Run()
+}
+
+type BlockTestRunner struct {
+	*BaseTestRunner
+	Expected *ast.Block
+}
+
+func NewBlockTestRunner(t *testing.T, name string, text []rune, expected *ast.Block, args ...interface{}) *BlockTestRunner {
+	parserArgFuncs, rest1 := FilterParserArgFuncs(args)
+	baseRunnerFuncs, rest2 := FilterBaseTestRunnerFuncs(rest1)
+	if len(rest2) > 0 {
+		panic(errors.Errorf("unexpected arguments: %v", rest2))
+	}
+	r := &BlockTestRunner{
+		BaseTestRunner: NewBaseTestRunner(t, name, &text, true, parserArgFuncs, baseRunnerFuncs),
+		Expected:       expected,
+	}
+	return r
+}
+
+func (tt *BlockTestRunner) Run() *BlockTestRunner {
+	tt.BaseTestRunner.Run(
+		func() (astcore.Node, error) {
+			args := tt.ParserArgFuncs.Results()
+			p := NewTestProgramParser(tt.Text, args...)
+			p.NextToken()
+			r, err := p.ParseBlock()
+			return r, err
+		},
+		func(t *testing.T, actual astcore.Node) {
+			if !assert.Equal(t, tt.Expected, actual) {
+				if assert.IsType(t, tt.Expected, actual) {
+					asttest.AssertBlock(t, tt.Expected, actual.(*ast.Block))
+				}
+			}
+		},
+	)
+	return tt
+}

--- a/parser/parsertest/type_pointer_test.go
+++ b/parser/parsertest/type_pointer_test.go
@@ -90,6 +90,8 @@ end;
 				Ident: asttest.NewIdent("PInteger"),
 				Type:  ast.NewCustomPointerType(asttest.NewOrdIdentWithIdent(asttest.NewIdent("Integer"))),
 			}
+			declPInteger := typeDeclPInteger.ToDeclarations()[0]
+
 			varDeclR := &ast.VarDecl{
 				IdentList: asttest.NewIdentList("R"),
 				Type:      asttest.NewRealType("Single"),
@@ -104,9 +106,8 @@ end;
 			}
 			varDeclPI := &ast.VarDecl{
 				IdentList: asttest.NewIdentList("PI"),
-				Type:      ast.NewTypeId(asttest.NewIdent("PInteger")),
+				Type:      ast.NewTypeId(asttest.NewIdent("PInteger"), declPInteger),
 			}
-			declPInteger := typeDeclPInteger.ToDeclarations()[0]
 			declR := varDeclR.ToDeclarations()[0]
 			declI := varDeclI.ToDeclarations()[0]
 			declP := varDeclP.ToDeclarations()[0]

--- a/parser/parsertest/type_pointer_test.go
+++ b/parser/parsertest/type_pointer_test.go
@@ -1,0 +1,148 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/akm/tparser/ast"
+	"github.com/akm/tparser/ast/asttest"
+)
+
+func TestPointerType(t *testing.T) {
+
+	RunBlockTest(t,
+		"with pointer variable",
+		[]rune(`
+var
+	X, Y: Integer;
+	P: ^Integer;
+begin
+	X := 17;
+	P := @X;
+	Y := P^;
+end;
+`),
+		&ast.Block{
+			DeclSections: ast.DeclSections{
+				ast.VarSection{
+					{
+						IdentList: asttest.NewIdentList("X", "Y"),
+						Type:      asttest.NewOrdIdent("Integer"),
+					},
+					{
+						IdentList: asttest.NewIdentList("P"),
+						Type:      ast.NewCustomPointerType(asttest.NewOrdIdentWithIdent(asttest.NewIdent("Integer"))),
+					},
+				},
+			},
+			Body: &ast.CompoundStmt{
+				StmtList: ast.StmtList{
+					&ast.Statement{
+						Body: &ast.AssignStatement{
+							Designator: asttest.NewDesignator(asttest.NewIdent("X")),
+							Expression: asttest.NewExpression(asttest.NewNumber("17")),
+						},
+					},
+					&ast.Statement{
+						Body: &ast.AssignStatement{
+							Designator: asttest.NewDesignator(asttest.NewIdent("P")),
+							Expression: asttest.NewExpression(&ast.Address{Designator: asttest.NewDesignator(asttest.NewIdent("X"))}),
+						},
+					},
+					&ast.Statement{
+						Body: &ast.AssignStatement{
+							Designator: asttest.NewDesignator(asttest.NewIdent("Y")),
+							Expression: asttest.NewExpression(
+								&ast.Designator{
+									QualId: asttest.NewQualId(asttest.NewIdent("P")),
+									Items:  ast.DesignatorItems{&ast.DesignatorItemDereference{}},
+								},
+							),
+						},
+					},
+				},
+			},
+		},
+	)
+
+	RunBlockTest(t,
+		"with pointer type declaration",
+		[]rune(`
+type
+	PInteger = ^Integer;
+var
+	R: Single;	
+	I: Integer;
+	P: Pointer;
+	PI: PInteger;
+begin
+	P := @R;
+	PI := PInteger(P);
+	I := PI^;
+end;
+`),
+		&ast.Block{
+			DeclSections: ast.DeclSections{
+				ast.TypeSection{
+					{
+						Ident: asttest.NewIdent("PInteger"),
+						Type:  ast.NewCustomPointerType(asttest.NewOrdIdentWithIdent(asttest.NewIdent("Integer"))),
+					},
+				},
+				ast.VarSection{
+					{
+						IdentList: asttest.NewIdentList("R"),
+						Type:      asttest.NewRealType("Single"),
+					},
+					{
+						IdentList: asttest.NewIdentList("R"),
+						Type:      asttest.NewOrdIdent("Single"),
+					},
+					{
+						IdentList: asttest.NewIdentList("P"),
+						Type:      ast.NewEmbeddedPointerType(asttest.NewIdent("Pointer")),
+					},
+					{
+						IdentList: asttest.NewIdentList("P"),
+						Type:      ast.NewTypeId(asttest.NewIdent("PInteger")),
+					},
+				},
+			},
+			Body: &ast.CompoundStmt{
+				StmtList: ast.StmtList{
+					&ast.Statement{
+						Body: &ast.AssignStatement{
+							Designator: asttest.NewDesignator(asttest.NewIdent("P")),
+							Expression: asttest.NewExpression(&ast.Address{Designator: asttest.NewDesignator(asttest.NewIdent("R"))}),
+						},
+					},
+					&ast.Statement{
+						Body: &ast.AssignStatement{
+							Designator: asttest.NewDesignator(asttest.NewIdent("PI")),
+							Expression: asttest.NewExpression(
+								&ast.TypeCast{
+									TypeId: ast.NewTypeId(asttest.NewIdent("PInteger")),
+									Expression: asttest.NewExpression(
+										asttest.NewQualId(asttest.NewIdent("P")),
+									),
+								},
+							),
+						},
+					},
+					&ast.Statement{
+						Body: &ast.AssignStatement{
+							Designator: asttest.NewDesignator(asttest.NewIdent("I")),
+							Expression: asttest.NewExpression(
+								&ast.Designator{
+									QualId: asttest.NewQualId(asttest.NewIdent("PI")),
+									Items:  ast.DesignatorItems{&ast.DesignatorItemDereference{}},
+								},
+							),
+						},
+					},
+				},
+			},
+		},
+	)
+
+	// TODO tests for PChar, PAnsiChar, PWideChar
+}

--- a/parser/parsertest/type_pointer_test.go
+++ b/parser/parsertest/type_pointer_test.go
@@ -21,47 +21,52 @@ begin
 	Y := P^;
 end;
 `),
-		&ast.Block{
-			DeclSections: ast.DeclSections{
-				ast.VarSection{
-					{
-						IdentList: asttest.NewIdentList("X", "Y"),
-						Type:      asttest.NewOrdIdent("Integer"),
-					},
-					{
-						IdentList: asttest.NewIdentList("P"),
-						Type:      ast.NewCustomPointerType(asttest.NewOrdIdentWithIdent(asttest.NewIdent("Integer"))),
+		func() *ast.Block {
+
+			varDeclXY := &ast.VarDecl{
+				IdentList: asttest.NewIdentList("X", "Y"),
+				Type:      asttest.NewOrdIdent("Integer"),
+			}
+			varDeclP := &ast.VarDecl{
+				IdentList: asttest.NewIdentList("P"),
+				Type:      ast.NewCustomPointerType(asttest.NewOrdIdentWithIdent(asttest.NewIdent("Integer"))),
+			}
+			declX := varDeclXY.ToDeclarations()[0]
+			declY := varDeclXY.ToDeclarations()[1]
+			declP := varDeclP.ToDeclarations()[0]
+			return &ast.Block{
+				DeclSections: ast.DeclSections{
+					ast.VarSection{varDeclXY, varDeclP},
+				},
+				Body: &ast.CompoundStmt{
+					StmtList: ast.StmtList{
+						&ast.Statement{
+							Body: &ast.AssignStatement{
+								Designator: asttest.NewDesignator(asttest.NewIdentRef("X", declX)),
+								Expression: asttest.NewExpression(asttest.NewNumber("17")),
+							},
+						},
+						&ast.Statement{
+							Body: &ast.AssignStatement{
+								Designator: asttest.NewDesignator(asttest.NewIdentRef("P", declP)),
+								Expression: asttest.NewExpression(&ast.Address{Designator: asttest.NewDesignator(asttest.NewIdentRef("X", declX))}),
+							},
+						},
+						&ast.Statement{
+							Body: &ast.AssignStatement{
+								Designator: asttest.NewDesignator(asttest.NewIdentRef("Y", declY)),
+								Expression: asttest.NewExpression(
+									&ast.Designator{
+										QualId: asttest.NewQualId(asttest.NewIdentRef("P", declP)),
+										Items:  ast.DesignatorItems{&ast.DesignatorItemDereference{}},
+									},
+								),
+							},
+						},
 					},
 				},
-			},
-			Body: &ast.CompoundStmt{
-				StmtList: ast.StmtList{
-					&ast.Statement{
-						Body: &ast.AssignStatement{
-							Designator: asttest.NewDesignator(asttest.NewIdent("X")),
-							Expression: asttest.NewExpression(asttest.NewNumber("17")),
-						},
-					},
-					&ast.Statement{
-						Body: &ast.AssignStatement{
-							Designator: asttest.NewDesignator(asttest.NewIdent("P")),
-							Expression: asttest.NewExpression(&ast.Address{Designator: asttest.NewDesignator(asttest.NewIdent("X"))}),
-						},
-					},
-					&ast.Statement{
-						Body: &ast.AssignStatement{
-							Designator: asttest.NewDesignator(asttest.NewIdent("Y")),
-							Expression: asttest.NewExpression(
-								&ast.Designator{
-									QualId: asttest.NewQualId(asttest.NewIdent("P")),
-									Items:  ast.DesignatorItems{&ast.DesignatorItemDereference{}},
-								},
-							),
-						},
-					},
-				},
-			},
-		},
+			}
+		}(),
 	)
 
 	RunBlockTest(t,
@@ -80,68 +85,73 @@ begin
 	I := PI^;
 end;
 `),
-		&ast.Block{
-			DeclSections: ast.DeclSections{
-				ast.TypeSection{
-					{
-						Ident: asttest.NewIdent("PInteger"),
-						Type:  ast.NewCustomPointerType(asttest.NewOrdIdentWithIdent(asttest.NewIdent("Integer"))),
-					},
+		func() *ast.Block {
+			typeDeclPInteger := &ast.TypeDecl{
+				Ident: asttest.NewIdent("PInteger"),
+				Type:  ast.NewCustomPointerType(asttest.NewOrdIdentWithIdent(asttest.NewIdent("Integer"))),
+			}
+			varDeclR := &ast.VarDecl{
+				IdentList: asttest.NewIdentList("R"),
+				Type:      asttest.NewRealType("Single"),
+			}
+			varDeclI := &ast.VarDecl{
+				IdentList: asttest.NewIdentList("I"),
+				Type:      asttest.NewOrdIdent("Integer"),
+			}
+			varDeclP := &ast.VarDecl{
+				IdentList: asttest.NewIdentList("P"),
+				Type:      ast.NewEmbeddedPointerType(asttest.NewIdent("Pointer")),
+			}
+			varDeclPI := &ast.VarDecl{
+				IdentList: asttest.NewIdentList("PI"),
+				Type:      ast.NewTypeId(asttest.NewIdent("PInteger")),
+			}
+			declPInteger := typeDeclPInteger.ToDeclarations()[0]
+			declR := varDeclR.ToDeclarations()[0]
+			declI := varDeclI.ToDeclarations()[0]
+			declP := varDeclP.ToDeclarations()[0]
+			declPI := varDeclPI.ToDeclarations()[0]
+			return &ast.Block{
+				DeclSections: ast.DeclSections{
+					ast.TypeSection{typeDeclPInteger},
+					ast.VarSection{varDeclR, varDeclI, varDeclP, varDeclPI},
 				},
-				ast.VarSection{
-					{
-						IdentList: asttest.NewIdentList("R"),
-						Type:      asttest.NewRealType("Single"),
-					},
-					{
-						IdentList: asttest.NewIdentList("R"),
-						Type:      asttest.NewOrdIdent("Single"),
-					},
-					{
-						IdentList: asttest.NewIdentList("P"),
-						Type:      ast.NewEmbeddedPointerType(asttest.NewIdent("Pointer")),
-					},
-					{
-						IdentList: asttest.NewIdentList("P"),
-						Type:      ast.NewTypeId(asttest.NewIdent("PInteger")),
-					},
-				},
-			},
-			Body: &ast.CompoundStmt{
-				StmtList: ast.StmtList{
-					&ast.Statement{
-						Body: &ast.AssignStatement{
-							Designator: asttest.NewDesignator(asttest.NewIdent("P")),
-							Expression: asttest.NewExpression(&ast.Address{Designator: asttest.NewDesignator(asttest.NewIdent("R"))}),
+				Body: &ast.CompoundStmt{
+					StmtList: ast.StmtList{
+						&ast.Statement{
+							Body: &ast.AssignStatement{
+								Designator: asttest.NewDesignator(asttest.NewIdentRef("P", declP)),
+								Expression: asttest.NewExpression(&ast.Address{Designator: asttest.NewDesignator(asttest.NewIdentRef("R", declR))}),
+							},
+						},
+						&ast.Statement{
+							Body: &ast.AssignStatement{
+								Designator: asttest.NewDesignator(asttest.NewIdentRef("PI", declPI)),
+								Expression: asttest.NewExpression(
+									&ast.TypeCast{
+										TypeId: ast.NewTypeId(asttest.NewIdentRef("PInteger", declPInteger)),
+										Expression: asttest.NewExpression(
+											asttest.NewQualId(asttest.NewIdentRef("P", declP)),
+										),
+									},
+								),
+							},
+						},
+						&ast.Statement{
+							Body: &ast.AssignStatement{
+								Designator: asttest.NewDesignator(asttest.NewIdentRef("I", declI)),
+								Expression: asttest.NewExpression(
+									&ast.Designator{
+										QualId: asttest.NewQualId(asttest.NewIdentRef("PI", declPI)),
+										Items:  ast.DesignatorItems{&ast.DesignatorItemDereference{}},
+									},
+								),
+							},
 						},
 					},
-					&ast.Statement{
-						Body: &ast.AssignStatement{
-							Designator: asttest.NewDesignator(asttest.NewIdent("PI")),
-							Expression: asttest.NewExpression(
-								&ast.TypeCast{
-									TypeId: ast.NewTypeId(asttest.NewIdent("PInteger")),
-									Expression: asttest.NewExpression(
-										asttest.NewQualId(asttest.NewIdent("P")),
-									),
-								},
-							),
-						},
-					},
-					&ast.Statement{
-						Body: &ast.AssignStatement{
-							Designator: asttest.NewDesignator(asttest.NewIdent("I")),
-							Expression: asttest.NewExpression(
-								&ast.Designator{
-									QualId: asttest.NewQualId(asttest.NewIdent("PI")),
-									Items:  ast.DesignatorItems{&ast.DesignatorItemDereference{}},
-								},
-							),
-						},
-					},
 				},
-			},
-		},
+			}
+		}(),
 	)
 
 	// TODO tests for PChar, PAnsiChar, PWideChar

--- a/parser/pcontext/program_context.go
+++ b/parser/pcontext/program_context.go
@@ -32,7 +32,7 @@ func NewProgramContext(args ...interface{}) *ProgramContext {
 		units = ast.Units{}
 	}
 	if declarationMap == nil {
-		declarationMap = astcore.NewDeclMap()
+		declarationMap = astcore.NewChainedDeclMap(ast.EmbeddedTypeDeclMap)
 	}
 	return &ProgramContext{
 		Path:    path,

--- a/parser/pcontext/unit_context.go
+++ b/parser/pcontext/unit_context.go
@@ -26,7 +26,7 @@ func NewUnitContext(parent *ProgramContext, args ...interface{}) *UnitContext {
 		}
 	}
 	if declarationMap == nil {
-		declarationMap = astcore.NewDeclMap()
+		declarationMap = astcore.NewChainedDeclMap(ast.EmbeddedTypeDeclMap)
 	}
 	return &UnitContext{
 		Parent:  parent,

--- a/parser/type.go
+++ b/parser/type.go
@@ -87,6 +87,8 @@ func (p *Parser) ParseType() (ast.Type, error) {
 	case token.SpecialSymbol:
 		if t1.Is(token.Symbol('(')) {
 			return p.ParseEnumeratedType()
+		} else if t1.Is(token.Symbol('^')) {
+			return p.ParseCustomPointerType()
 		}
 	case token.Identifier:
 		return p.ParseTypeForIdentifier()
@@ -155,4 +157,16 @@ func (p *Parser) parseTypeIdWithoutUnit() (*ast.TypeId, error) {
 	}
 
 	return r, nil
+}
+
+func (p *Parser) ParseCustomPointerType() (*ast.CustomPointerType, error) {
+	if _, err := p.Current(token.Symbol('^')); err != nil {
+		return nil, err
+	}
+	p.NextToken()
+	typ, err := p.ParseTypeId()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.CustomPointerType{TypeId: typ}, nil
 }

--- a/parser/type_struc.go
+++ b/parser/type_struc.go
@@ -92,7 +92,7 @@ func (p *Parser) ParseArrayType() (*ast.ArrayType, error) {
 	}
 	r.BaseType = baseType
 
-	if p.NextToken().Is(token.ReservedWord.HasKeyword("PACKED")) {
+	if p.CurrentToken().Is(token.ReservedWord.HasKeyword("PACKED")) {
 		r.Packed = true
 		p.NextToken()
 	}


### PR DESCRIPTION
- Add `EtkPointerType` 
- Add `EmbeddedPointer` `EmbeddedPChar` `EmbeddedPAnsiChar` `EmbeddedPWideChar` 
- Add `PointerType` interface
    - implemented by
        - `TypeId`
        - `CustomPointerType` (new)
- Define `EmbeddedTypeDeclMap` variable
    - used as `DeclMap`
        - in ProjectContext
        - in UnitContext
- Implement `ParseCustomPointerType`
- Consider type cast in `ParseFactor`
