### PR TITLE
Procedure type support

### DIFF
--- a/Grammer.md
+++ b/Grammer.md
@@ -4,9 +4,9 @@ See also [Object Pascal Guide](https://docs.embarcadero.com/products/rad_studio/
 
 | Mark | State       | Count |
 | :--: | ----------- | ----: |
-|  🔖  | TODO        |    33 |
+|  🔖  | TODO        |    31 |
 |  🚧  | In progress |     6 |
-|  ✔️  | Done        |    83 |
+|  ✔️  | Done        |    85 |
 
 - Goal 🚧
   ```
@@ -343,11 +343,11 @@ See also [Object Pascal Guide](https://docs.embarcadero.com/products/rad_studio/
   ```
   FILE OF TypeId [PortabilityDirective]
   ```
-- PointerType 🔖
+- PointerType ✔️
   ```
   '^' TypeId [PortabilityDirective]
   ```
-- ProcedureType 🔖
+- ProcedureType ✔️
   ```
   (ProcedureHeading | FunctionHeading) [OF OBJECT]
   ```

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ go test ./...
 
 | Mark | State       | Count | Percentage |
 | :--: | ----------- | ----: |---------:|
-|  🔖  | TODO        |    33 |  27.0% |
+|  🔖  | TODO        |    31 |  25.4% |
 |  🚧  | In progress |     6 | 4.9% |
-|  ✔️  | Done        |    83 | **68.0%** |
+|  ✔️  | Done        |    85 | **69.7%** |
 |     | Total        | 122 |  100.0%  |
 
 See [Grammer.md](./Grammer.md) for more details.

--- a/ast/asttest/type_simple.go
+++ b/ast/asttest/type_simple.go
@@ -26,5 +26,5 @@ func NewOrdIdent(name interface{}) ast.OrdIdent {
 }
 
 func NewOrdIdentWithIdent(v *ast.Ident) *ast.TypeId {
-	return ast.NewOrdIdentWithIdent(v)
+	return ast.NewOrdIdent(v)
 }

--- a/ast/asttest/type_simple.go
+++ b/ast/asttest/type_simple.go
@@ -5,7 +5,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func NewRealType(name interface{}) ast.RealType {
+func NewRealType(name interface{}) *ast.TypeId {
 	switch v := name.(type) {
 	case string:
 		return ast.NewRealType(NewIdent(v))
@@ -16,7 +16,7 @@ func NewRealType(name interface{}) ast.RealType {
 	}
 }
 
-func NewOrdIdent(name interface{}) ast.OrdIdent {
+func NewOrdIdent(name interface{}) *ast.TypeId {
 	switch v := name.(type) {
 	case string:
 		return ast.NewOrdIdent(NewIdent(v))

--- a/ast/asttest/type_simple.go
+++ b/ast/asttest/type_simple.go
@@ -2,6 +2,7 @@ package asttest
 
 import (
 	"github.com/akm/tparser/ast"
+	"github.com/pkg/errors"
 )
 
 func NewRealType(name interface{}) ast.RealType {
@@ -17,8 +18,10 @@ func NewOrdIdent(name interface{}) ast.OrdIdent {
 	switch v := name.(type) {
 	case string:
 		return ast.NewOrdIdent(NewIdent(v))
+	case *ast.Ident:
+		return ast.NewOrdIdent(v)
 	default:
-		return ast.NewOrdIdent(name)
+		panic(errors.Errorf("invalid type %T for NewOrdIdent %+v", name, name))
 	}
 }
 

--- a/ast/asttest/type_simple.go
+++ b/ast/asttest/type_simple.go
@@ -9,8 +9,10 @@ func NewRealType(name interface{}) ast.RealType {
 	switch v := name.(type) {
 	case string:
 		return ast.NewRealType(NewIdent(v))
+	case *ast.Ident:
+		return ast.NewRealType(v)
 	default:
-		return ast.NewRealType(name)
+		panic(errors.Errorf("invalid type %T for asttest.NewRealType %+v", name, name))
 	}
 }
 

--- a/ast/asttest/type_string.go
+++ b/ast/asttest/type_string.go
@@ -4,7 +4,7 @@ import (
 	"github.com/akm/tparser/ast"
 )
 
-func NewStringType(name interface{}) ast.StringType {
+func NewStringType(name interface{}) *ast.TypeId {
 	return ast.NewStringType(NewIdent(name))
 }
 

--- a/ast/function_heading.go
+++ b/ast/function_heading.go
@@ -54,7 +54,7 @@ type FunctionHeading struct {
 	Type FunctionType
 	*Ident
 	FormalParameters FormalParameters
-	ReturnType       Type
+	ReturnType       *TypeId
 }
 
 func (*FunctionHeading) isExportedHeading() {}

--- a/ast/type_procedure.go
+++ b/ast/type_procedure.go
@@ -1,0 +1,32 @@
+package ast
+
+// This is WRONG because ProcedureHeading and FunctionHeading have ident.
+// - ProcedureType 🔖
+//   ```
+//   (ProcedureHeading | FunctionHeading) [OF OBJECT]
+//   ```
+//
+// Actual:
+// ```
+// (FUNCTION | PROCEDURE) [FormalParameters] [':' (TypeId)] [of object]
+// ```
+
+type ProcedureType struct {
+	FunctionType     FunctionType
+	FormalParameters FormalParameters
+	ReturnType       *TypeId
+	OfObject         bool
+	Type
+}
+
+func (*ProcedureType) isType() {}
+func (m ProcedureType) Children() Nodes {
+	r := Nodes{}
+	if m.FormalParameters != nil {
+		r = append(r, m.FormalParameters)
+	}
+	if m.ReturnType != nil {
+		r = append(r, m.ReturnType)
+	}
+	return r
+}

--- a/ast/type_simple.go
+++ b/ast/type_simple.go
@@ -117,15 +117,11 @@ type OrdIdent interface {
 	OrdinalType
 }
 
-func NewOrdIdent(ident *Ident) OrdIdent {
-	return NewOrdIdentWithIdent(ident)
-}
-
-func NewOrdIdentWithIdent(v *Ident) *TypeId {
-	if decl := EmbeddedTypeDecl(EtkOrdIdent, v.Name); decl != nil {
-		return NewTypeId(v, decl)
+func NewOrdIdent(ident *Ident) *TypeId {
+	if decl := EmbeddedTypeDecl(EtkOrdIdent, ident.Name); decl != nil {
+		return NewTypeId(ident, decl)
 	} else {
-		return NewTypeId(v)
+		return NewTypeId(ident)
 	}
 }
 

--- a/ast/type_simple.go
+++ b/ast/type_simple.go
@@ -117,17 +117,8 @@ type OrdIdent interface {
 	OrdinalType
 }
 
-func NewOrdIdent(name interface{}) OrdIdent {
-	switch v := name.(type) {
-	case OrdIdent:
-		return v
-	case Ident:
-		return NewOrdIdentWithIdent(&v)
-	case *Ident:
-		return NewOrdIdentWithIdent(v)
-	default:
-		panic(errors.Errorf("invalid type %T for NewOrdIndent %+v", name, name))
-	}
+func NewOrdIdent(ident *Ident) OrdIdent {
+	return NewOrdIdentWithIdent(ident)
 }
 
 func NewOrdIdentWithIdent(v *Ident) *TypeId {

--- a/ast/type_simple.go
+++ b/ast/type_simple.go
@@ -41,7 +41,7 @@ type RealType interface {
 	SimpleType
 }
 
-func NewRealType(ident *Ident) RealType {
+func NewRealType(ident *Ident) *TypeId {
 	if decl := EmbeddedTypeDecl(EtkReal, ident.Name); decl != nil {
 		return NewTypeId(ident, decl)
 	} else {

--- a/ast/type_simple.go
+++ b/ast/type_simple.go
@@ -2,7 +2,6 @@ package ast
 
 import (
 	"github.com/akm/tparser/ast/astcore"
-	"github.com/pkg/errors"
 )
 
 // - SimpleType
@@ -42,24 +41,11 @@ type RealType interface {
 	SimpleType
 }
 
-func NewRealType(name interface{}) RealType {
-	switch v := name.(type) {
-	case RealType:
-		return v
-	case Ident:
-		if decl := EmbeddedTypeDecl(EtkReal, v.Name); decl != nil {
-			return NewTypeId(&v, decl)
-		} else {
-			return NewTypeId(&v)
-		}
-	case *Ident:
-		if decl := EmbeddedTypeDecl(EtkReal, v.Name); decl != nil {
-			return NewTypeId(v, decl)
-		} else {
-			return NewTypeId(v)
-		}
-	default:
-		panic(errors.Errorf("invalid type %T for NewRealType %+v", name, name))
+func NewRealType(ident *Ident) RealType {
+	if decl := EmbeddedTypeDecl(EtkReal, ident.Name); decl != nil {
+		return NewTypeId(ident, decl)
+	} else {
+		return NewTypeId(ident)
 	}
 }
 

--- a/ast/type_string.go
+++ b/ast/type_string.go
@@ -19,7 +19,7 @@ type StringType interface {
 	Type
 }
 
-func NewStringType(ident *Ident) StringType {
+func NewStringType(ident *Ident) *TypeId {
 	if decl := EmbeddedTypeDecl(EtkStringType, ident.Name); decl != nil {
 		return NewTypeId(ident, decl)
 	} else {

--- a/ast/type_string.go
+++ b/ast/type_string.go
@@ -1,9 +1,5 @@
 package ast
 
-import (
-	"github.com/pkg/errors"
-)
-
 // - StringType
 //   ```
 //   STRING
@@ -23,18 +19,11 @@ type StringType interface {
 	Type
 }
 
-func NewStringType(name interface{}) StringType {
-	switch v := name.(type) {
-	case StringType:
-		return v
-	case *Ident:
-		if decl := EmbeddedTypeDecl(EtkStringType, v.Name); decl != nil {
-			return NewTypeId(v, decl)
-		} else {
-			return NewTypeId(v)
-		}
-	default:
-		panic(errors.Errorf("invalid type %T for NewStringType %+v", name, name))
+func NewStringType(ident *Ident) StringType {
+	if decl := EmbeddedTypeDecl(EtkStringType, ident.Name); decl != nil {
+		return NewTypeId(ident, decl)
+	} else {
+		return NewTypeId(ident)
 	}
 }
 
@@ -43,8 +32,8 @@ type FixedStringType struct {
 	Length *ConstExpr
 }
 
-func NewFixedStringType(name interface{}, length *ConstExpr) *FixedStringType {
-	return &FixedStringType{StringType: NewStringType(name), Length: length}
+func NewFixedStringType(ident *Ident, length *ConstExpr) *FixedStringType {
+	return &FixedStringType{StringType: NewStringType(ident), Length: length}
 }
 
 func (*FixedStringType) isType()            {}

--- a/parser/function.go
+++ b/parser/function.go
@@ -8,14 +8,7 @@ import (
 func (p *Parser) ParseProcedureDeclSection() (*ast.FunctionDecl, error) {
 	var functionHeading *ast.FunctionHeading
 	switch p.CurrentToken().Value() {
-	case "PROCEDURE":
-		defer p.context.StackDeclMap()()
-		var err error
-		functionHeading, err = p.ParseProcedureHeading()
-		if err != nil {
-			return nil, err
-		}
-	case "FUNCTION":
+	case "PROCEDURE", "FUNCTION":
 		defer p.context.StackDeclMap()()
 		var err error
 		functionHeading, err = p.ParseFunctionHeading()

--- a/parser/function_heading.go
+++ b/parser/function_heading.go
@@ -170,7 +170,7 @@ func (p *Parser) ParseFunctionHeading() (*ast.FunctionHeading, error) {
 		return nil, err
 	}
 	p.NextToken()
-	typ, err := p.ParseType()
+	typ, err := p.ParseTypeId()
 	if err != nil {
 		return nil, err
 	}

--- a/parser/parsertest/expression_test.go
+++ b/parser/parsertest/expression_test.go
@@ -193,7 +193,7 @@ func TestExpression(t *testing.T) {
 		[]rune(`Char(48)`),
 		asttest.NewExpression(
 			&ast.TypeCast{
-				TypeId: ast.NewOrdIdentWithIdent(asttest.NewIdent("Char", asttest.NewIdentLocation(1, 1, 0, 5))),
+				TypeId: ast.NewOrdIdent(asttest.NewIdent("Char", asttest.NewIdentLocation(1, 1, 0, 5))),
 				Expression: asttest.NewExpression(
 					asttest.NewNumber("48"),
 				),

--- a/parser/parsertest/type_procedure_test.go
+++ b/parser/parsertest/type_procedure_test.go
@@ -1,0 +1,145 @@
+package parsertest
+
+import (
+	"testing"
+
+	"github.com/akm/tparser/ast"
+	"github.com/akm/tparser/ast/asttest"
+)
+
+func TestProcedureType(t *testing.T) {
+
+	RunVarSectionTest(t,
+		"var with procedure type definition",
+		[]rune(`var F: function(X,Y: Integer): Integer;`),
+		ast.VarSection{
+			&ast.VarDecl{
+				IdentList: asttest.NewIdentList("F"),
+				Type: &ast.ProcedureType{
+					FunctionType: ast.FtFunction,
+					FormalParameters: ast.FormalParameters{
+						asttest.NewFormalParm([]string{"X", "Y"}, asttest.NewOrdIdent("Integer")),
+					},
+					ReturnType: asttest.NewOrdIdent("Integer"),
+				},
+			},
+		},
+	)
+
+	RunUnitTest(t,
+		"procedure type declaration and vars",
+		[]rune(`UNIT U1;
+interface
+type
+	TIntegerFunction = function: Integer;
+	TProcedure = procedure;
+	TStrProc = procedure(const S: string);
+	TMathFunc = function(X: Double): Double;
+var
+	F: TIntegerFunction;
+	Proc: TProcedure;
+	SP: TStrProc;
+	M: TMathFunc;
+
+procedure FuncProc(P: TIntegerFunction);	
+
+implementation
+end.`),
+		func() *ast.Unit {
+			typeDeclTIntegerFunction := &ast.TypeDecl{
+				Ident: asttest.NewIdent("TIntegerFunction"),
+				Type: &ast.ProcedureType{
+					FunctionType: ast.FtFunction,
+					ReturnType:   asttest.NewOrdIdent("Integer"),
+				},
+			}
+			typeDeclTProcedure := &ast.TypeDecl{
+				Ident: asttest.NewIdent("TProcedure"),
+				Type:  &ast.ProcedureType{FunctionType: ast.FtProcedure},
+			}
+			typeDeclTStrProc := &ast.TypeDecl{
+				Ident: asttest.NewIdent("TStrProc"),
+				Type: &ast.ProcedureType{
+					FunctionType: ast.FtProcedure,
+					FormalParameters: ast.FormalParameters{
+						asttest.NewFormalParm("S", asttest.NewStringType("string"), "CONST"),
+					},
+				},
+			}
+			typeDeclTMathFunc := &ast.TypeDecl{
+				Ident: asttest.NewIdent("TMathFunc"),
+				Type: &ast.ProcedureType{
+					FunctionType: ast.FtFunction,
+					FormalParameters: ast.FormalParameters{
+						asttest.NewFormalParm("X", asttest.NewRealType("Double")),
+					},
+					ReturnType: asttest.NewRealType("Double"),
+				},
+			}
+
+			declTIntegerFunction := typeDeclTIntegerFunction.ToDeclarations()[0]
+			declTProcedure := typeDeclTProcedure.ToDeclarations()[0]
+			declTStrProc := typeDeclTStrProc.ToDeclarations()[0]
+			declTMathFunc := typeDeclTMathFunc.ToDeclarations()[0]
+
+			return &ast.Unit{
+				Ident: asttest.NewIdent("U1"),
+				InterfaceSection: &ast.InterfaceSection{
+					InterfaceDecls: ast.InterfaceDecls{
+						ast.TypeSection{
+							typeDeclTIntegerFunction,
+							typeDeclTProcedure,
+							typeDeclTStrProc,
+							typeDeclTMathFunc,
+						},
+						ast.VarSection{
+							&ast.VarDecl{IdentList: asttest.NewIdentList("F"), Type: asttest.NewTypeId("TIntegerFunction", declTIntegerFunction)},
+							&ast.VarDecl{IdentList: asttest.NewIdentList("Proc"), Type: asttest.NewTypeId("TProcedure", declTProcedure)},
+							&ast.VarDecl{IdentList: asttest.NewIdentList("SP"), Type: asttest.NewTypeId("TStrProc", declTStrProc)},
+							&ast.VarDecl{IdentList: asttest.NewIdentList("M"), Type: asttest.NewTypeId("TMathFunc", declTMathFunc)},
+						},
+						&ast.ExportedHeading{
+							FunctionHeading: &ast.FunctionHeading{
+								Type:  ast.FtProcedure,
+								Ident: asttest.NewIdent("FuncProc"),
+								FormalParameters: ast.FormalParameters{
+									asttest.NewFormalParm("P", asttest.NewTypeId("TIntegerFunction", declTIntegerFunction)),
+								},
+							},
+						},
+					},
+				},
+				ImplementationSection: &ast.ImplementationSection{},
+			}
+		}(),
+	)
+
+	RunTypeSection(t,
+		"Object method type declaration",
+		[]rune(`
+type
+	TMethod = procedure of object;
+	TNotifyEvent = procedure(Sender: TObject) of object;
+`),
+		ast.TypeSection{
+			&ast.TypeDecl{
+				Ident: asttest.NewIdent("TMethod"),
+				Type: &ast.ProcedureType{
+					FunctionType: ast.FtProcedure,
+					OfObject:     true,
+				},
+			},
+			&ast.TypeDecl{
+				Ident: asttest.NewIdent("TNotifyEvent"),
+				Type: &ast.ProcedureType{
+					FunctionType: ast.FtProcedure,
+					FormalParameters: ast.FormalParameters{
+						asttest.NewFormalParm("Sender", asttest.NewTypeId("TObject")),
+					},
+					OfObject: true,
+				},
+			},
+		},
+	)
+
+}

--- a/parser/type.go
+++ b/parser/type.go
@@ -98,6 +98,8 @@ func (p *Parser) ParseType() (ast.Type, error) {
 		switch t1.Value() {
 		case "PACKED", "ARRAY", "SET", "RECORD", "FILE":
 			return p.ParseStrucType()
+		case "FUNCTION", "PROCEDURE":
+			return p.ParseProcedureType()
 		default:
 			return p.ParseStringOfStringType()
 		}

--- a/parser/type_procedure.go
+++ b/parser/type_procedure.go
@@ -1,0 +1,51 @@
+package parser
+
+import (
+	"github.com/akm/tparser/ast"
+	"github.com/akm/tparser/token"
+)
+
+func (p *Parser) ParseProcedureType() (*ast.ProcedureType, error) {
+	res := &ast.ProcedureType{}
+
+	t0 := p.CurrentToken()
+	switch t0.Value() {
+	case "FUNCTION":
+		res.FunctionType = ast.FtFunction
+	case "PROCEDURE":
+		res.FunctionType = ast.FtProcedure
+	default:
+		return nil, p.TokenErrorf("expects FUNCTION or PROCEDURE, but got %s (%s)", t0, string(t0.Raw()))
+	}
+
+	t := p.NextToken()
+	if t.Is(token.Symbol('(')) {
+		formalParameters, err := p.ParseFormalParameters()
+		if err != nil {
+			return nil, err
+		}
+		res.FormalParameters = formalParameters
+	}
+	if res.FunctionType == ast.FtFunction {
+		if _, err := p.Current(token.Symbol(':')); err != nil {
+			return nil, err
+		}
+		p.NextToken()
+		typ, err := p.ParseTypeId()
+		if err != nil {
+			return nil, err
+		}
+		res.ReturnType = typ
+	}
+
+	if p.CurrentToken().Is(token.ReservedWord.HasKeyword("OF")) {
+		p.NextToken()
+		if _, err := p.Current(token.ReservedWord.HasKeyword("OBJECT")); err != nil {
+			return nil, err
+		}
+		res.OfObject = true
+		p.NextToken()
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
## Refactoring

- Use *ast.TypeId for
    - ast.NewStringType
    - ast.NewOrdIdent
    - ast.NewRealType
- Merge ParseProcedureHeading into ParseFunctionHeading https://github.com/akm/tparser/commit/c042b6456e4cff9ebe51818d28df9f7933ba435f

##  New 

- Define `ast.ProcedureType` struct
    - Implements `Type` interface
- Implement `Parser.ParseProcedureType`
