### PR TITLE
Add test for independency of declaration of function parameters

### DIFF
--- a/ast/astcore/decl_map.go
+++ b/ast/astcore/decl_map.go
@@ -24,8 +24,8 @@ func (m DeclMapImpl) Set(decl DeclNode) error {
 		// 	err := errors.Errorf("bar found")
 		// 	fmt.Printf("%+v\n", err)
 		// }
-		if _, ok := m[s]; ok {
-			return errors.Errorf("duplicate declaration: %s", i.Ident.Name)
+		if old, ok := m[s]; ok {
+			return errors.Errorf("duplicate declaration: %s at %s but was %s", i.Ident.Name, i.Ident.Location.String(), old.Location.String())
 		}
 		m[s] = i
 	}

--- a/parser/parsertest/type_procedure_test.go
+++ b/parser/parsertest/type_procedure_test.go
@@ -114,6 +114,143 @@ end.`),
 		}(),
 	)
 
+	RunUnitTest(t,
+		"procedures with same name parameter",
+		[]rune(`UNIT U1;
+interface
+type
+	TStrProc1 = procedure(S: string);
+	TStrProc2 = procedure(S: string);
+
+procedure Proc1(S: string);
+procedure Proc2(S: string);
+
+implementation
+
+procedure Proc1(S: string);
+begin
+	Writeln(S);
+end;
+
+procedure Proc2(S: string);
+begin
+	Writeln(S);
+end;
+
+end.`),
+		func() *ast.Unit {
+			typeDeclTStrProc1 := &ast.TypeDecl{
+				Ident: asttest.NewIdent("TStrProc1"),
+				Type: &ast.ProcedureType{
+					FunctionType:     ast.FtProcedure,
+					FormalParameters: ast.FormalParameters{asttest.NewFormalParm("S", asttest.NewStringType("string"))},
+				},
+			}
+			typeDeclTStrProc2 := &ast.TypeDecl{
+				Ident: asttest.NewIdent("TStrProc2"),
+				Type: &ast.ProcedureType{
+					FunctionType:     ast.FtProcedure,
+					FormalParameters: ast.FormalParameters{asttest.NewFormalParm("S", asttest.NewStringType("string"))},
+				},
+			}
+
+			paramSinProc1 := asttest.NewFormalParm("S", asttest.NewStringType("string"))
+			paramSinProc2 := asttest.NewFormalParm("S", asttest.NewStringType("string"))
+
+			return &ast.Unit{
+				Ident: asttest.NewIdent("U1"),
+				InterfaceSection: &ast.InterfaceSection{
+					InterfaceDecls: ast.InterfaceDecls{
+						ast.TypeSection{
+							typeDeclTStrProc1,
+							typeDeclTStrProc2,
+						},
+						&ast.ExportedHeading{
+							FunctionHeading: &ast.FunctionHeading{
+								Type:             ast.FtProcedure,
+								Ident:            asttest.NewIdent("Proc1"),
+								FormalParameters: ast.FormalParameters{asttest.NewFormalParm("S", asttest.NewStringType("string"))},
+							},
+						},
+						&ast.ExportedHeading{
+							FunctionHeading: &ast.FunctionHeading{
+								Type:             ast.FtProcedure,
+								Ident:            asttest.NewIdent("Proc2"),
+								FormalParameters: ast.FormalParameters{asttest.NewFormalParm("S", asttest.NewStringType("string"))},
+							},
+						},
+					},
+				},
+				ImplementationSection: &ast.ImplementationSection{
+					DeclSections: ast.DeclSections{
+						&ast.FunctionDecl{
+							FunctionHeading: &ast.FunctionHeading{
+								Type:             ast.FtProcedure,
+								Ident:            asttest.NewIdent("Proc1"),
+								FormalParameters: ast.FormalParameters{paramSinProc1},
+							},
+							Block: &ast.Block{
+								Body: &ast.CompoundStmt{
+									StmtList: ast.StmtList{
+										{
+											Body: &ast.CallStatement{
+												Designator: asttest.NewDesignator(
+													asttest.NewQualId(
+														asttest.NewIdent("Writeln"),
+													),
+												),
+												ExprList: ast.ExprList{
+													asttest.NewExpression(
+														&ast.DesignatorFactor{
+															Designator: asttest.NewDesignator(
+																&ast.QualId{Ident: asttest.NewIdentRef("S", paramSinProc1.ToDeclarations()[0])},
+															),
+														},
+													),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						&ast.FunctionDecl{
+							FunctionHeading: &ast.FunctionHeading{
+								Type:             ast.FtProcedure,
+								Ident:            asttest.NewIdent("Proc2"),
+								FormalParameters: ast.FormalParameters{asttest.NewFormalParm("S", asttest.NewStringType("string"))},
+							},
+							Block: &ast.Block{
+								Body: &ast.CompoundStmt{
+									StmtList: ast.StmtList{
+										{
+											Body: &ast.CallStatement{
+												Designator: asttest.NewDesignator(
+													asttest.NewQualId(
+														asttest.NewIdent("Writeln"),
+													),
+												),
+												ExprList: ast.ExprList{
+													asttest.NewExpression(
+														&ast.DesignatorFactor{
+															Designator: asttest.NewDesignator(
+																&ast.QualId{Ident: asttest.NewIdentRef("S", paramSinProc2.ToDeclarations()[0])},
+															),
+														},
+													),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+		}(),
+	)
+
 	RunTypeSection(t,
 		"Object method type declaration",
 		[]rune(`

--- a/parser/type_procedure.go
+++ b/parser/type_procedure.go
@@ -18,6 +18,8 @@ func (p *Parser) ParseProcedureType() (*ast.ProcedureType, error) {
 		return nil, p.TokenErrorf("expects FUNCTION or PROCEDURE, but got %s (%s)", t0, string(t0.Raw()))
 	}
 
+	defer p.context.StackDeclMap()()
+
 	t := p.NextToken()
 	if t.Is(token.Symbol('(')) {
 		formalParameters, err := p.ParseFormalParameters()

--- a/parser/unit_parser.go
+++ b/parser/unit_parser.go
@@ -207,6 +207,8 @@ func (p *UnitParser) ParseImplUses() error {
 		return err
 	}
 	p.NextToken()
+
+	// Ignore returned func
 	p.context.StackDeclMap()
 
 	impl := &ast.ImplementationSection{}


### PR DESCRIPTION
- Add test https://github.com/akm/tparser/pull/61/commits/ab085045a03b53b53ddf6b912ca106be8bf87b96
- Fix ParseProcedureType to call StackDeclMap

