### PR TITLE
Support forward delcaration

### DIFF
--- a/parser/parsertest/type_pointer_test.go
+++ b/parser/parsertest/type_pointer_test.go
@@ -223,4 +223,65 @@ end;
 		}(),
 	)
 
+	NewTypeSectionTestRunner(t,
+		"Forward declaration of PointerType",
+		[]rune(`
+type
+	PGUID = ^TGUID;
+	TGUID = packed record
+		D1: Longword;
+		D2: Word;
+		D3: Word;
+		D4: array[0..7] of Byte;
+	end;
+`),
+		func() ast.TypeSection {
+			tguidType := &ast.RecType{
+				Packed: true,
+				FieldList: &ast.FieldList{
+					FieldDecls: ast.FieldDecls{
+						{
+							IdentList: asttest.NewIdentList("D1"),
+							Type:      asttest.NewOrdIdent("Longword"),
+						},
+						{
+							IdentList: asttest.NewIdentList("D2"),
+							Type:      asttest.NewOrdIdent("Word"),
+						},
+						{
+							IdentList: asttest.NewIdentList("D3"),
+							Type:      asttest.NewOrdIdent("Word"),
+						},
+						{
+							IdentList: asttest.NewIdentList("D4"),
+							Type: &ast.ArrayType{
+								IndexTypes: []ast.OrdinalType{
+									&ast.SubrangeType{
+										Low:  asttest.NewConstExpr(asttest.NewNumber("0")),
+										High: asttest.NewConstExpr(asttest.NewNumber("7")),
+									},
+								},
+								BaseType: ast.NewOrdIdent(asttest.NewIdent("Byte")),
+							},
+						},
+					},
+				},
+			}
+
+			recDecl := &ast.TypeDecl{
+				Ident: asttest.NewIdent("TGUID"),
+				Type:  tguidType,
+			}
+			pointerDecl := &ast.TypeDecl{
+				Ident: asttest.NewIdent("PGUID"),
+				Type:  ast.NewCustomPointerType(asttest.NewTypeId("TGUID", recDecl.ToDeclarations()[0])),
+			}
+
+			return ast.TypeSection{
+				pointerDecl,
+				recDecl,
+			}
+		}(),
+	).Run()
+
 }

--- a/parser/type.go
+++ b/parser/type.go
@@ -17,6 +17,8 @@ func (p *Parser) ParseTypeSection(required bool) (ast.TypeSection, error) {
 			return nil, nil
 		}
 	}
+	defer p.SetupPostSectionFuncs()()
+
 	p.NextToken()
 	res := ast.TypeSection{}
 	for {
@@ -40,6 +42,8 @@ func (p *Parser) ParseTypeSection(required bool) (ast.TypeSection, error) {
 			break
 		}
 	}
+	p.RunPostSectionFuncs()
+
 	return res, nil
 }
 
@@ -175,6 +179,12 @@ func (p *Parser) parseTypeIdWithoutUnit() (*ast.TypeId, error) {
 
 	decl := p.context.Get(ident.Name)
 	if decl == nil {
+		p.AddPostSection(func() {
+			decl := p.context.Get(ident.Name)
+			if decl != nil {
+				r.Ref = decl
+			}
+		})
 		p.Logf("%s is not declared", ident.Name)
 	} else {
 		r.Ref = decl


### PR DESCRIPTION
Support type declaratoin like the following:

```delphi
type
	PGUID = ^TGUID;
	TGUID = packed record
		D1: Longword;
		D2: Word;
		D3: Word;
		D4: array[0..7] of Byte;
	end;
```
